### PR TITLE
Add created_at to the mock response

### DIFF
--- a/wiremock/mappings/job-service.json
+++ b/wiremock/mappings/job-service.json
@@ -8,7 +8,7 @@
       },
       "response": {
         "status": 200,
-        "body": "[{\"job_id\": \"123-123-123-123\", \"operation\": \"ADD\", \"status\": \"completed\", \"parameters\": {\"target\": \"INNTEKT\",\"operation\": \"ADD\"}}]"
+        "body": "[{\"job_id\": \"123-123-123-123\", \"operation\": \"ADD\", \"status\": \"completed\", \"parameters\": {\"target\": \"INNTEKT\",\"operation\": \"ADD\"},\"created_at\": \"2022-05-18T11:40:22.519222\"}]"
       }
     },
     {


### PR DESCRIPTION
This is necessary since it's a mandatory field for job executor to interpret queued jobs