### PR TITLE
Ensure that we delete the backup folder prior to executing the tests

### DIFF
--- a/tests/unit/adapter/test_local_storage.py
+++ b/tests/unit/adapter/test_local_storage.py
@@ -39,6 +39,10 @@ MOVED_WORKING_DIR_DATASET_DATA_PATH = (
 
 
 def setup_module():
+
+    if os.path.isdir('tests/resources_backup'):
+        shutil.rmtree('tests/resources_backup')
+
     shutil.copytree(
         'tests/resources',
         'tests/resources_backup'

--- a/tests/unit/model/test_datastore_version.py
+++ b/tests/unit/model/test_datastore_version.py
@@ -53,6 +53,10 @@ DATASTORE_VERSION = {
 
 
 def setup_function():
+
+    if os.path.isdir('tests/resources_backup'):
+        shutil.rmtree('tests/resources_backup')
+
     shutil.copytree(
         'tests/resources',
         'tests/resources_backup'

--- a/tests/unit/model/test_datastore_versions.py
+++ b/tests/unit/model/test_datastore_versions.py
@@ -14,6 +14,10 @@ DATASTORE_VERSIONS_PATH = f'{DATASTORE_DIR}/datastore_versions.json'
 
 
 def setup_function():
+
+    if os.path.isdir('tests/resources_backup'):
+        shutil.rmtree('tests/resources_backup')
+
     shutil.copytree(
         'tests/resources',
         'tests/resources_backup'

--- a/tests/unit/model/test_metadata.py
+++ b/tests/unit/model/test_metadata.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 
 from job_executor.model import MetadataAll, Metadata
@@ -20,6 +21,10 @@ PATCHED_METADATA = load_json(f'{TEST_DIR}/patched_metadata.json')
 
 
 def setup_module():
+
+    if os.path.isdir('tests/resources_backup'):
+        shutil.rmtree('tests/resources_backup')
+
     shutil.copytree(
         'tests/resources',
         'tests/resources_backup'

--- a/tests/unit/worker/steps/test_dataset_pseudonymizer.py
+++ b/tests/unit/worker/steps/test_dataset_pseudonymizer.py
@@ -1,6 +1,7 @@
 # test good case
 # test bad case
 import json
+import os
 import shutil
 import pytest
 
@@ -35,6 +36,10 @@ def set_working_dir(monkeypatch):
 
 
 def setup_function():
+
+    if os.path.isdir(f'{WORKING_DIR}_backup'):
+        shutil.rmtree(f'{WORKING_DIR}_backup')
+
     shutil.copytree(WORKING_DIR, f'{WORKING_DIR}_backup')
 
 

--- a/tests/unit/worker/test_build_dataset_worker.py
+++ b/tests/unit/worker/test_build_dataset_worker.py
@@ -178,6 +178,10 @@ EXPECTED_REQUESTS_IMPORT = [
 
 
 def setup_function():
+
+    if os.path.isdir('tests/resources_backup'):
+        shutil.rmtree('tests/resources_backup')
+
     shutil.copytree(
         'tests/resources',
         'tests/resources_backup'


### PR DESCRIPTION
Otherwise we risk that the tests fail since the folder may already exist, which will be the case if we abort the test execution and then attempt to re-run them

Note: we should perhaps also notify the would-be-tester that issuing a 'git restore' may be necessary to restore the repo to a "clean state" in case we fail to clean up after the tests. 