### PR TITLE
Temp backup for bump

### DIFF
--- a/job_executor/adapter/job_service.py
+++ b/job_executor/adapter/job_service.py
@@ -23,7 +23,7 @@ def get_jobs(
     if query_fields:
         request_url += f'?{"&".join(query_fields)}'
 
-    response = requests.get(request_url)
+    response = requests.get(request_url, timeout=10)
     if response.status_code != 200:
         raise HttpResponseError(f'{response.text}')
     return [Job(**job) for job in response.json()]
@@ -35,7 +35,8 @@ def update_job_status(job_id: str, new_status: JobStatus, log: str = None):
         payload.update({'log': log})
     response = requests.put(
         f'{JOB_SERVICE_URL}/jobs/{job_id}',
-        json=payload
+        json=payload,
+        timeout=10
     )
     if response.status_code != 200:
         raise HttpResponseError(f'{response.text}')
@@ -44,7 +45,8 @@ def update_job_status(job_id: str, new_status: JobStatus, log: str = None):
 def update_description(job_id: str, new_description: str):
     response = requests.put(
         f'{JOB_SERVICE_URL}/jobs/{job_id}',
-        json={'description': new_description}
+        json={'description': new_description},
+        timeout=10
     )
     if response.status_code != 200:
         raise HttpResponseError(f'{response.status_code}: {response.text}')

--- a/job_executor/adapter/local_storage.py
+++ b/job_executor/adapter/local_storage.py
@@ -291,7 +291,8 @@ def delete_parquet_draft(dataset_name: str) -> None:
     elif os.path.isfile(f'{parquet_path}.parquet'):
         os.remove(f'{parquet_path}.parquet')
 
-def delete_files(file_list : list[str]):
+
+def delete_files(file_list: list[str]):
     """
     Deletes a list of files. Intended to clean up left-over csv files
     * file_list: list[str] - list of csv files to delete

--- a/job_executor/adapter/pseudonym_service.py
+++ b/job_executor/adapter/pseudonym_service.py
@@ -22,7 +22,7 @@ def pseudonymize(idents: List[str], unit_id_type: str, job_id: str) -> dict:
             'Content-Type': 'application/json',
             'X-API-Key': PSEUDONYM_SERVICE_API_KEY
         },
-        timeout=10
+        timeout=4000
     )
     if response.status_code != 200:
         raise HttpResponseError(

--- a/job_executor/adapter/pseudonym_service.py
+++ b/job_executor/adapter/pseudonym_service.py
@@ -21,7 +21,8 @@ def pseudonymize(idents: List[str], unit_id_type: str, job_id: str) -> dict:
         headers={
             'Content-Type': 'application/json',
             'X-API-Key': PSEUDONYM_SERVICE_API_KEY
-        }
+        },
+        timeout=10
     )
     if response.status_code != 200:
         raise HttpResponseError(

--- a/job_executor/app.py
+++ b/job_executor/app.py
@@ -7,11 +7,12 @@ from multiprocessing import Process, Queue
 
 import json_logging
 
+from job_executor.adapter import local_storage
 from job_executor.model import Job, Datastore
 from job_executor.adapter import job_service
 from job_executor.config import environment
 from job_executor.config.log import CustomJSONLog
-from job_executor.exception import UnknownOperationException
+from job_executor.exception import LocalStorageError, UnknownOperationException
 from job_executor.worker import (
     build_dataset_worker,
     build_metadata_worker
@@ -75,10 +76,28 @@ def main():
                     job_service.update_job_status(
                         job.job_id, 'completed'
                     )
-                except Exception as e:
+                    if job.parameters.operation == 'BUMP':
+                        local_storage.delete_temporary_backup()
+                except LocalStorageError as e:
+                    logger.error(f'{job.job_id} failed')
+                    logger.exception(e)
                     job_service.update_job_status(
                         job.job_id, 'failed',
-                        log=str(e)
+                        log='Failed due to error with local storage'
+                    )
+                except UnknownOperationException as e:
+                    logger.error(f'{job.job_id} failed')
+                    logger.exception(e)
+                    job_service.update_job_status(
+                        job.job_id, 'failed',
+                        log='Unknown operation for job'
+                    )
+                except Exception as e:
+                    logger.error(f'{job.job_id} failed')
+                    logger.exception(e)
+                    job_service.update_job_status(
+                        job.job_id, 'failed',
+                        log='Failed due to unexpected error'
                     )
     except Exception as e:
         logger.exception(e)
@@ -117,6 +136,7 @@ def _handle_worker_job(job: Job, workers: List[Process], logging_queue: Queue):
 def _handle_manager_job(job: Job):
     operation = job.parameters.operation
     if operation == 'BUMP':
+        local_storage.save_temporary_backup()
         datastore.bump_version(
             job.parameters.bump_manifesto,
             job.parameters.description

--- a/job_executor/app.py
+++ b/job_executor/app.py
@@ -2,20 +2,20 @@ import sys
 import threading
 import time
 import logging
-from multiprocessing import Process, Queue
 from typing import List
+from multiprocessing import Process, Queue
 
 import json_logging
 
+from job_executor.model import Job, Datastore
+from job_executor.adapter import job_service
+from job_executor.config import environment
 from job_executor.config.log import CustomJSONLog
 from job_executor.exception import UnknownOperationException
 from job_executor.worker import (
     build_dataset_worker,
     build_metadata_worker
 )
-from job_executor.model import Job, Datastore
-from job_executor.adapter import job_service
-from job_executor.config import environment
 
 
 NUMBER_OF_WORKERS = environment.get('NUMBER_OF_WORKERS')

--- a/job_executor/app.py
+++ b/job_executor/app.py
@@ -65,11 +65,17 @@ def main():
                 job_status='queued',
                 operations=['SET_STATUS', 'BUMP', 'DELETE_DRAFT', 'REMOVE']
             )
-            logger.info(f'Found '
-                        f'{len(queued_worker_jobs)}'
-                        f'/{len(built_jobs)}'
-                        f'/{len(queued_manager_jobs)}'
-                        f' (worker, built, queued manager jobs)')
+            available_jobs = (
+                len(queued_worker_jobs) +
+                len(built_jobs) +
+                len(queued_manager_jobs)
+            )
+            if available_jobs:
+                logger.info(
+                    f'Found {len(queued_worker_jobs)}/{len(built_jobs)}'
+                    f'/{len(queued_manager_jobs)}'
+                    f' (worker, built, queued manager jobs)'
+                )
             for job in built_jobs + queued_manager_jobs:
                 try:
                     _handle_manager_job(job)

--- a/job_executor/config/log.py
+++ b/job_executor/config/log.py
@@ -31,8 +31,8 @@ class ContextFilter(logging.Filter):
 def configure_worker_logger(queue: Queue, job_id: str):
     queue_handler = logging.handlers.QueueHandler(queue)
     queue_handler.setLevel(logging.INFO)
-    # use default formatter here so that the JSON formatter will be applied when
-    # reading from queue
+    # use default formatter here so that the JSON formatter will be
+    # applied when reading from queue
     queue_handler.formatter = logging.Formatter()
 
     log_filter = ContextFilter(job_id)

--- a/job_executor/exception/__init__.py
+++ b/job_executor/exception/__init__.py
@@ -36,3 +36,7 @@ class MetadataException(Exception):
 
 class BumpException(Exception):
     ...
+
+
+class LocalStorageError(Exception):
+    ...

--- a/job_executor/model/datastore.py
+++ b/job_executor/model/datastore.py
@@ -190,7 +190,7 @@ class Datastore():
             )
         release_updates, update_type = self.draft_version.release_pending()
         # If there are no released versions update type will always be MAJOR
-        if self.metadata_all_latest == None:
+        if self.metadata_all_latest is None:
             update_type = 'MAJOR'
         new_version = self.datastore_versions.add_new_release_version(
             release_updates, description, update_type

--- a/job_executor/model/metadata.py
+++ b/job_executor/model/metadata.py
@@ -303,7 +303,7 @@ class Metadata(CamelModel):
             )
         if len(self.attribute_variables) != len(other.attribute_variables):
             raise PatchingError('Can not delete or add attributeVariables')
-        
+
         if self.sensitivity_level != other.sensitivity_level:
             raise PatchingError('Can not change sensitivity level')
 
@@ -358,4 +358,4 @@ class Metadata(CamelModel):
         }
         if self.temporal_status_dates is None:
             del metadata_dict['temporalStatusDates']
-        return metadata_dict  
+        return metadata_dict

--- a/job_executor/worker/build_dataset_worker.py
+++ b/job_executor/worker/build_dataset_worker.py
@@ -24,7 +24,7 @@ def run_worker(job_id: str, dataset_name: str, logging_queue: Queue):
     start = perf_counter()
     logger = logging.getLogger()
     consumed_files: list[str] = []
-    
+
     try:
         configure_worker_logger(logging_queue, job_id)
         logger.info(
@@ -39,16 +39,16 @@ def run_worker(job_id: str, dataset_name: str, logging_queue: Queue):
         input_metadata = local_storage.get_working_dir_input_metadata(
             dataset_name
         )
-        
+
         consumed_files.append(f'{WORKING_DIR}/{dataset_name}.db')
-        
+
         description = input_metadata['dataRevision']['description'][0]['value']
         job_service.update_description(job_id, description)
 
         job_service.update_job_status(job_id, 'transforming')
         transformed_metadata = dataset_transformer.run(metadata_file_path)
         consumed_files.append(metadata_file_path)
-        
+
         temporality_type = transformed_metadata.temporality
         temporal_coverage = transformed_metadata.temporal_coverage.dict()
         data_type = transformed_metadata.measure_variable.data_type

--- a/job_executor/worker/build_metadata_worker.py
+++ b/job_executor/worker/build_metadata_worker.py
@@ -34,7 +34,7 @@ def run_worker(job_id: str, dataset_name: str, logging_queue: Queue):
         input_metadata = local_storage.get_working_dir_input_metadata(
             dataset_name
         )
-        description = input_metadata['dataRevision']['description'][0]['value']        
+        description = input_metadata['dataRevision']['description'][0]['value']
         job_service.update_description(job_id, description)
 
         job_service.update_job_status(job_id, 'transforming')

--- a/job_executor/worker/steps/dataset_transformer.py
+++ b/job_executor/worker/steps/dataset_transformer.py
@@ -1,8 +1,7 @@
-import logging
 import json
-from datetime import datetime
-import os
+import logging
 from pathlib import Path
+from datetime import datetime
 
 from job_executor.exception import BuilderStepError
 from job_executor.model import Metadata
@@ -156,7 +155,11 @@ def _represented_variables_from_code_list(description: str,
 
 
 def _transform_variable(
-    variable: dict, role: str, start: str, stop: str):
+    variable: dict,
+    role: str,
+    start: str,
+    stop: str
+):
     variable_description = (
         _get_norwegian_text(variable['description'])
         if 'description' in variable else 'N/A'

--- a/tests/unit/adapter/test_local_storage.py
+++ b/tests/unit/adapter/test_local_storage.py
@@ -42,7 +42,7 @@ MOVED_WORKING_DIR_DATASET_DATA_PATH = (
 )
 
 
-def setup_module():
+def setup_function():
     if os.path.isdir('tests/resources_backup'):
         shutil.rmtree('tests/resources_backup')
     shutil.copytree(
@@ -51,7 +51,7 @@ def setup_module():
     )
 
 
-def teardown_module():
+def teardown_function():
     shutil.rmtree('tests/resources')
     shutil.move(
         'tests/resources_backup',
@@ -158,6 +158,7 @@ def test_rename_parquet_draft_to_release():
 
 
 def test_move_working_dir_parquet_to_datastore():
+    local_storage.make_dataset_dir(WORKING_DIR_DATASET)
     local_storage.move_working_dir_parquet_to_datastore(WORKING_DIR_DATASET)
     assert os.path.isfile(MOVED_WORKING_DIR_DATASET_DATA_PATH)
 
@@ -182,12 +183,16 @@ def test_make_temp_directory():
 
 
 def test_make_temp_directory_already_exists():
+    local_storage.save_temporary_backup()
+    datastore_content = os.listdir(DATASTORE_DIR)
+    assert 'tmp' in datastore_content
     with pytest.raises(LocalStorageError) as e:
         local_storage.save_temporary_backup()
     assert '/tmp directory already exists' in str(e)
 
 
 def test_delete_temp_directory():
+    local_storage.save_temporary_backup()
     datastore_content = os.listdir(DATASTORE_DIR)
     local_storage.delete_temporary_backup()
     datastore_content_delete = os.listdir(DATASTORE_DIR)


### PR DESCRIPTION
# TEMP BACKUP BEFORE BUMP

Before a bump operation these files will be backed up:
* draft_version.json
* datastore_versions.json
* metadata_all__DRAFT.json
After the bump is completed these files are then deleted

### What's changed?
* New backup and delete backup functions for local_storage adapter
* call backup functions in the manager
* smaller cleanups
* This has been tested with the datastore-testing integration tests and runs as expected
* Only log result of querying job-service for jobs if any jobs have been found waiting. This avoids the service logging excessively when no work has been queued

### What's next?
Next PR will be adding startup functionality that first queries for unfinished jobs. If such jobs are found the job-executor will rollback from backups to avoid being out-of-synch with reality.