### PR TITLE
Epoch seconds in files

### DIFF
--- a/job_executor/model/datastore_version.py
+++ b/job_executor/model/datastore_version.py
@@ -28,6 +28,11 @@ class DatastoreVersion(CamelModel):
             for update in self.data_structure_updates
         ])
 
+    def _get_current_epoch_seconds(self):
+        return int(
+            (datetime.now() - datetime.utcfromtimestamp(0)).total_seconds()
+        )
+
     def _calculate_update_type(self):
         pending_operations = [
             update.operation for update in self.data_structure_updates
@@ -82,9 +87,7 @@ class DraftVersion(DatastoreVersion):
                 f'Draft for {data_structure_update.name} already exists'
             )
         self.data_structure_updates.append(data_structure_update)
-        self.release_time = int(
-            (datetime.now() - datetime.utcfromtimestamp(0)).total_seconds()
-        )
+        self.release_time = self._get_current_epoch_seconds()
         self._calculate_update_type()
         self._write_to_file()
 
@@ -105,9 +108,7 @@ class DraftVersion(DatastoreVersion):
             update for update in self.data_structure_updates
             if update.name != dataset_name
         ]
-        self.release_time = int(
-            (datetime.now() - datetime.utcfromtimestamp(0)).total_seconds()
-        )
+        self.release_time = self._get_current_epoch_seconds()
         self._calculate_update_type()
         self._write_to_file()
         return deleted_draft
@@ -142,9 +143,7 @@ class DraftVersion(DatastoreVersion):
                 pending_updates.append(update)
         update_type = self.update_type
         self.data_structure_updates = draft_updates
-        self.release_time = int(
-            (datetime.now() - datetime.utcfromtimestamp(0)).total_seconds()
-        )
+        self.release_time = self._get_current_epoch_seconds()
         self._calculate_update_type()
         self._write_to_file()
         return pending_updates, update_type
@@ -164,8 +163,6 @@ class DraftVersion(DatastoreVersion):
                 f'Status already set to {new_status}'
             )
         dataset_update.set_release_status(new_status)
-        self.release_time = int(
-            (datetime.now() - datetime.utcfromtimestamp(0)).total_seconds()
-        )
+        self.release_time = self._get_current_epoch_seconds()
         self._calculate_update_type()
         self._write_to_file()

--- a/job_executor/model/datastore_version.py
+++ b/job_executor/model/datastore_version.py
@@ -83,7 +83,7 @@ class DraftVersion(DatastoreVersion):
             )
         self.data_structure_updates.append(data_structure_update)
         self.release_time = (
-            (datetime.now() - datetime.utcfromtimestamp(0)).days
+            (datetime.now() - datetime.utcfromtimestamp(0)).seconds
         )
         self._calculate_update_type()
         self._write_to_file()
@@ -106,7 +106,7 @@ class DraftVersion(DatastoreVersion):
             if update.name != dataset_name
         ]
         self.release_time = (
-            (datetime.now() - datetime.utcfromtimestamp(0)).days
+            (datetime.now() - datetime.utcfromtimestamp(0)).seconds
         )
         self._calculate_update_type()
         self._write_to_file()
@@ -143,10 +143,7 @@ class DraftVersion(DatastoreVersion):
         update_type = self.update_type
         self.data_structure_updates = draft_updates
         self.release_time = (
-            (datetime.now() - datetime.utcfromtimestamp(0)).days
-        )
-        self.release_time = (
-            (datetime.now() - datetime.utcfromtimestamp(0)).days
+            (datetime.now() - datetime.utcfromtimestamp(0)).seconds
         )
         self._calculate_update_type()
         self._write_to_file()

--- a/job_executor/model/datastore_version.py
+++ b/job_executor/model/datastore_version.py
@@ -82,8 +82,8 @@ class DraftVersion(DatastoreVersion):
                 f'Draft for {data_structure_update.name} already exists'
             )
         self.data_structure_updates.append(data_structure_update)
-        self.release_time = (
-            (datetime.now() - datetime.utcfromtimestamp(0)).seconds
+        self.release_time = int(
+            (datetime.now() - datetime.utcfromtimestamp(0)).total_seconds()
         )
         self._calculate_update_type()
         self._write_to_file()
@@ -105,8 +105,8 @@ class DraftVersion(DatastoreVersion):
             update for update in self.data_structure_updates
             if update.name != dataset_name
         ]
-        self.release_time = (
-            (datetime.now() - datetime.utcfromtimestamp(0)).seconds
+        self.release_time = int(
+            (datetime.now() - datetime.utcfromtimestamp(0)).total_seconds()
         )
         self._calculate_update_type()
         self._write_to_file()
@@ -142,8 +142,8 @@ class DraftVersion(DatastoreVersion):
                 pending_updates.append(update)
         update_type = self.update_type
         self.data_structure_updates = draft_updates
-        self.release_time = (
-            (datetime.now() - datetime.utcfromtimestamp(0)).seconds
+        self.release_time = int(
+            (datetime.now() - datetime.utcfromtimestamp(0)).total_seconds()
         )
         self._calculate_update_type()
         self._write_to_file()
@@ -164,8 +164,8 @@ class DraftVersion(DatastoreVersion):
                 f'Status already set to {new_status}'
             )
         dataset_update.set_release_status(new_status)
-        self.release_time = (
-            (datetime.now() - datetime.utcfromtimestamp(0)).seconds
+        self.release_time = int(
+            (datetime.now() - datetime.utcfromtimestamp(0)).total_seconds()
         )
         self._calculate_update_type()
         self._write_to_file()

--- a/job_executor/model/datastore_versions.py
+++ b/job_executor/model/datastore_versions.py
@@ -50,7 +50,9 @@ class DatastoreVersions(CamelModel, extra=Extra.forbid):
         new_release_version = DatastoreVersion(
             version=new_version_number,
             description=description,
-            release_time=(datetime.now() - datetime.utcfromtimestamp(0)).days,
+            release_time=(
+                (datetime.now() - datetime.utcfromtimestamp(0)).seconds
+            ),
             language_code='no',
             updateType=update_type,
             data_structure_updates=released_data_structure_updates

--- a/job_executor/model/datastore_versions.py
+++ b/job_executor/model/datastore_versions.py
@@ -24,6 +24,11 @@ class DatastoreVersions(CamelModel, extra=Extra.forbid):
     def _write_to_file(self):
         local_storage.write_datastore_versions(self.dict(by_alias=True))
 
+    def _get_current_epoch_seconds(self):
+        return int(
+            (datetime.now() - datetime.utcfromtimestamp(0)).total_seconds()
+        )
+
     def add_new_release_version(
         self,
         data_structure_updates: List[DataStructureUpdate],
@@ -50,9 +55,7 @@ class DatastoreVersions(CamelModel, extra=Extra.forbid):
         new_release_version = DatastoreVersion(
             version=new_version_number,
             description=description,
-            release_time=(
-                (datetime.now() - datetime.utcfromtimestamp(0)).seconds
-            ),
+            release_time=self._get_current_epoch_seconds(),
             language_code='no',
             updateType=update_type,
             data_structure_updates=released_data_structure_updates

--- a/tests/unit/model/test_datastore.py
+++ b/tests/unit/model/test_datastore.py
@@ -71,6 +71,7 @@ def test_patch_metadata(requests_mock: RequestsMocker):
         'operation': 'PATCH_METADATA',
         'releaseStatus': 'DRAFT'
     } in draft_version['dataStructureUpdates']
+    assert draft_version['releaseTime'] > 1_000_000
     assert sivstand_metadata in metadata_all_draft['dataStructures']
 
 
@@ -96,6 +97,7 @@ def test_add(requests_mock: RequestsMocker):
         'operation': 'ADD',
         'releaseStatus': 'DRAFT'
     } in draft_version['dataStructureUpdates']
+    assert draft_version['releaseTime'] > 1_000_000
     assert foedested_metadata in metadata_all_draft['dataStructures']
 
 
@@ -121,6 +123,7 @@ def test_change_data(requests_mock: RequestsMocker):
         'operation': 'CHANGE_DATA',
         'releaseStatus': 'DRAFT'
     } in draft_version['dataStructureUpdates']
+    assert draft_version['releaseTime'] > 1_000_000
     assert foedested_metadata in metadata_all_draft['dataStructures']
 
 
@@ -142,6 +145,7 @@ def test_remove(requests_mock: RequestsMocker):
         'operation': 'REMOVE',
         'releaseStatus': 'DRAFT'
     } in draft_version['dataStructureUpdates']
+    assert draft_version['releaseTime'] > 1_000_000
 
 
 def test_delete_draft(requests_mock: RequestsMocker):
@@ -162,6 +166,7 @@ def test_delete_draft(requests_mock: RequestsMocker):
         update for update in draft_version['dataStructureUpdates']
         if update['name'] == DATASET_NAME
     ]
+    assert draft_version['releaseTime'] > 1_000_000
 
 
 def test_set_draft_release_status(requests_mock: RequestsMocker):
@@ -198,6 +203,7 @@ def test_set_draft_release_status(requests_mock: RequestsMocker):
         'operation': 'ADD',
         'releaseStatus': 'PENDING_RELEASE'
     } in draft_version['dataStructureUpdates']
+    assert draft_version['releaseTime'] > 1_000_000
 
 
 def test_bump_datastore_minor(requests_mock: RequestsMocker):

--- a/tests/unit/model/test_datastore.py
+++ b/tests/unit/model/test_datastore.py
@@ -218,6 +218,7 @@ def test_bump_datastore_minor(requests_mock: RequestsMocker):
 
     with open(DRAFT_VERSION, encoding='utf-8') as f:
         draft_after_bump = json.load(f)
+    assert draft_after_bump['releaseTime'] > 1_000_000
     assert draft_after_bump['dataStructureUpdates'] == [
         {
             'description': 'oppdaterte metadata',
@@ -285,6 +286,7 @@ def test_bump_datastore_major(requests_mock: RequestsMocker):
 
     with open(DRAFT_VERSION, encoding='utf-8') as f:
         draft_after_bump = json.load(f)
+    assert draft_after_bump['releaseTime'] > 1_000_000
     assert draft_after_bump['dataStructureUpdates'] == [
         {
             'description': 'oppdaterte metadata',


### PR DESCRIPTION
# EPOCH SECONDS IN FILES
When updating the draft version or creating a new datastore version the release time should be set to seconds since epoch, and not days since epoch.
Added tests to check that the number written is above 1_000_000 (outside the range of epoch days)