### PR TITLE
bugfix_delete_draft: return from terminal job path

### DIFF
--- a/job_executor/model/datastore.py
+++ b/job_executor/model/datastore.py
@@ -264,6 +264,7 @@ class Datastore():
                     job_service.update_job_status(
                         job_id, 'failed', log_message
                     )
+                    return
                 self.metadata_all_draft.remove(dataset_name)
                 self.metadata_all_draft.add(released_metadata)
             if dataset_operation == 'ADD':

--- a/job_executor/model/datastore.py
+++ b/job_executor/model/datastore.py
@@ -313,8 +313,9 @@ class Datastore():
             dataset.dict(by_alias=True)
             for dataset in new_version_metadata
         ]
+        new_metadata_all = MetadataAll(**new_metadata_all_dict)
         local_storage.write_metadata_all(
-            new_metadata_all_dict, new_version
+            new_metadata_all.dict(by_alias=True), new_version
         )
         self.metadata_all_latest = MetadataAll(
             **local_storage.get_metadata_all(new_version)


### PR DESCRIPTION
# BUGFIX DELETE DRAFT

### What's changed?
* Return from terminating conditional in delete_draft method. This should technically never happen unless there has been ad-hoc editing of datastore files. We have layers-upon-layers of validation that ensures that a CHANGE_DATA, REMOVE or PATCH_METADATA is only added to draft if there is a released version. This return is still absolutely necessary, as it further "destoys" the datastore if the bug is ever reached.

* There is one point in the bump code where the creation of a new metadata_all file was not validated through the MetadataAll model. This could result in invalid metadata_all files being written.