### PR TITLE
Patch metadata: change implementation

### DIFF
--- a/job_executor/model/metadata.py
+++ b/job_executor/model/metadata.py
@@ -225,17 +225,13 @@ class Variable(CamelModel):
             return self
         if self.variable_role == "Measure" and self.key_type is not None:
             # Centralized variable definition was used,
-            # it is safe to only patch name and description fields.
-            new_name = other.name
+            # it is safe to only patch label and description fields.
             only_patch_description = True
             self.validate_patching_fields(other, with_key_type=True)
         else:
             self.validate_patching_fields(other, with_name=True)
-            new_name = self.name
 
-        self.validate_patching_for_all_variable_roles(
-            only_patch_description, other
-        )
+        self.validate_patching_for_all_variable_roles(other)
 
         patched_represented_variables = []
         for idx, _ in enumerate(self.represented_variables):
@@ -246,7 +242,7 @@ class Variable(CamelModel):
                 ).dict()
             )
         patched.update({
-            "name": new_name,
+            "name": self.name,
             "label": other.label,
             "notPseudonym": self.not_pseudonym,
             "dataType": self.data_type,
@@ -292,9 +288,7 @@ class Variable(CamelModel):
         if message:
             raise PatchingError(caption + message)
 
-    def validate_patching_for_all_variable_roles(
-        self, only_patch_description: bool, other: 'Variable'
-    ):
+    def validate_patching_for_all_variable_roles(self, other: 'Variable'):
         if self.key_type is None and other.key_type is not None:
             raise PatchingError('Can not change keyType')
         if len(self.represented_variables) != len(other.represented_variables):
@@ -305,11 +299,6 @@ class Variable(CamelModel):
             raise PatchingError(
                 'Can not change keyType pseudonym status from '
                 f'"{self.not_pseudonym}" to "{other.not_pseudonym}"'
-            )
-        if only_patch_description and self.label != other.label:
-            raise PatchingError(
-                'Can not change label from '
-                f'"{self.label}" to "{other.label}"'
             )
 
 

--- a/job_executor/model/metadata.py
+++ b/job_executor/model/metadata.py
@@ -317,7 +317,7 @@ class MeasureVariable(Variable):
                 'Please check unitType.requiresPseudonymization field. '
             )
 
-        return super()._patch_downstream(
+        return self._patch_downstream(
             other,
             True,
             skip_patching_represented_variables
@@ -331,7 +331,7 @@ class AttributeVariable(Variable):
 
         self.validate_patching_fields(other, with_name=True)
         self.validate_represented_variables(other)
-        return super()._patch_downstream(other)
+        return self._patch_downstream(other)
 
 
 class Metadata(CamelModel):

--- a/job_executor/model/metadata.py
+++ b/job_executor/model/metadata.py
@@ -19,27 +19,19 @@ class TimePeriod(CamelModel):
             else {"start": self.start}
         )
 
+    def __eq__(self, other):
+        return (
+            self.start == other.start and self.stop == other.stop
+        )
+
+    def __ne__(self, other):
+        return not self == other
+
 
 class KeyType(CamelModel):
     name: str
     label: str
     description: str
-
-    def patch(self, other: 'KeyType'):
-        if other is None:
-            raise PatchingError(
-                'Can not delete UnitType'
-            )
-        if self.name != other.name:
-            raise PatchingError(
-                'Can not change UnitType.shortName from '
-                f'"{self.name}" to "{other.name}"'
-            )
-        return KeyType(**{
-            'name': self.name,
-            'label': other.label,
-            'description': other.description
-        })
 
 
 class CodeListItem(CamelModel):
@@ -68,7 +60,7 @@ class ValueDomain(CamelModel):
     code_list: Optional[List[CodeListItem]]
     missing_values: Optional[List[str]]
 
-    def _is_enumerated_value_domain(self):
+    def is_enumerated_value_domain(self):
         return (
             self.code_list is not None
             and self.description is None
@@ -91,7 +83,7 @@ class ValueDomain(CamelModel):
                     "unitOfMeasure": self.unit_of_measure
                 }.items() if value is not None
             }
-        elif self._is_enumerated_value_domain():
+        elif self.is_enumerated_value_domain():
             return {
                 "codeList": [
                     code_item.dict() for code_item in self.code_list
@@ -115,7 +107,7 @@ class ValueDomain(CamelModel):
             if other.unit_of_measure is not None:
                 patched.update({'unitOfMeasure': other.unit_of_measure})
             return ValueDomain(**patched)
-        elif self._is_enumerated_value_domain():
+        elif self.is_enumerated_value_domain():
             if other.code_list is None:
                 raise PatchingError(
                     'Can not delete ValueDomain.codeList'
@@ -136,10 +128,13 @@ class ValueDomain(CamelModel):
                 patched.update({
                     'missingValues': [value for value in self.missing_values]
                 })
-            for idx, _ in enumerate(self.code_list):
+            sorted_code_list = sorted(self.code_list, key=lambda key: key.code)
+            sorted_other_code_list = sorted(
+                other.code_list, key=lambda key: key.code)
+            for idx, code_item in enumerate(sorted_code_list):
                 patched['codeList'].append(
-                    self.code_list[idx].patch(
-                        other.code_list[idx]
+                    code_item.patch(
+                        sorted_other_code_list[idx]
                     ).dict(by_alias=True)
                 )
             return ValueDomain(**patched)
@@ -152,21 +147,26 @@ class RepresentedVariable(CamelModel):
     valid_period: TimePeriod
     value_domain: ValueDomain
 
-    def patch(self, other: 'RepresentedVariable', only_patch_description: bool):
-        if other is None:
-            raise PatchingError(
-                'Can not delete RepresentedVariable. '
-                'Please check valueDomain.codeList field.'
-            )
+    def patch(self, other: 'RepresentedVariable'):
+        is_enumerated = self.value_domain.is_enumerated_value_domain()
+        if is_enumerated:
+            if self.valid_period != other.valid_period:
+                raise PatchingError(
+                    'Can not change codeList time span'
+                )
+
         return RepresentedVariable(**{
             "description": other.description,
             "validPeriod": self.valid_period.dict(by_alias=True),
-            "valueDomain": (
-                self.value_domain.dict(by_alias=True) if only_patch_description
-                else self.value_domain.patch(
-                    other.value_domain
-                ).dict(by_alias=True)
-            )
+            "valueDomain": self.value_domain.patch(other.value_domain)
+                                   .dict(by_alias=True)
+        })
+
+    def patch_description(self, description: str):
+        return RepresentedVariable(**{
+            "description": description,
+            "validPeriod": self.valid_period.dict(by_alias=True),
+            "valueDomain": self.value_domain.dict(by_alias=True)
         })
 
 
@@ -208,40 +208,6 @@ class Variable(CamelModel):
         if self.key_type is not None:
             dict_representation["keyType"] = self.key_type.dict(by_alias=True)
         return dict_representation
-
-    def _patch_downstream(
-        self, other: 'Variable',
-        only_patch_description: bool = False,
-        skip_patching_represented_variables: bool = False
-    ) -> 'Variable':
-        patched = {}
-        patched_represented_variables = []
-        if not skip_patching_represented_variables:
-            for idx, _ in enumerate(self.represented_variables):
-                patched_represented_variables.append(
-                    self.represented_variables[idx].patch(
-                        other.represented_variables[idx],
-                        only_patch_description
-                    ).dict()
-                )
-        patched.update({
-            "name": self.name,
-            "label": other.label,
-            "notPseudonym": self.not_pseudonym,
-            "dataType": self.data_type,
-            "variableRole": self.variable_role,
-            "representedVariables": self.represented_variables
-            if skip_patching_represented_variables
-            else patched_represented_variables
-        })
-        if self.format is not None:
-            patched.update({"format": self.format})
-        if self.key_type is not None:
-            patched.update({
-                'keyType': self.key_type.dict() if only_patch_description else
-                self.key_type.patch(other.key_type).dict()
-            })
-        return Variable(**patched)
 
     def validate_patching_fields(
         self, other, with_name: bool = False, with_key_type: bool = False
@@ -287,6 +253,13 @@ class IdentifierVariable(Variable):
     def patch(self, other: 'Variable') -> 'Variable':
         if other is None:
             raise PatchingError('Can not delete Variable')
+
+        if self.key_type.name != other.key_type.name:
+            raise PatchingError(
+                'Can not change Identifier unitType from '
+                f'{self.key_type.name} to {other.key_type.name}'
+            )
+
         # Centralized variable definition was used,
         # don't patch the one that is in the datastore.
         # The definition might have changed and we don't want to update it
@@ -296,42 +269,57 @@ class IdentifierVariable(Variable):
 
 class MeasureVariable(Variable):
     def patch(self, other: 'Variable') -> 'Variable':
-        skip_patching_represented_variables = False
+        centralized_variable_definition = False
         if other is None:
             raise PatchingError('Can not delete Variable')
         if self.key_type is not None:
+            if other.key_type is None:
+                raise PatchingError(f'Can not remove unitType: {self.key_type}')
             # Centralized variable definition was used,
             # it is safe to only patch label and description fields.
             self.validate_patching_fields(other, with_key_type=True)
-            skip_patching_represented_variables = True
+            centralized_variable_definition = True
         else:
             if other.key_type is not None:
-                raise PatchingError('Can not change unitType')
+                raise PatchingError(f'Can not add unitType: {other.key_type}')
             self.validate_patching_fields(other, with_name=True)
             self.validate_represented_variables(other)
 
-        if self.not_pseudonym != other.not_pseudonym:
-            raise PatchingError(
-                'Can not change unitType''s pseudonym status from '
-                f'"{self.not_pseudonym}" to "{other.not_pseudonym}"'
-                'Please check unitType.requiresPseudonymization field. '
-            )
+        patched = {}
+        patched_represented_variables = []
 
-        return self._patch_downstream(
-            other,
-            True,
-            skip_patching_represented_variables
-        )
+        if centralized_variable_definition:
+            description = other.represented_variables[0].description
+            patched_represented_variables = [
+                represented.patch_description(description) for represented
+                in self.represented_variables
+            ]
+        else:
+            for idx, _ in enumerate(self.represented_variables):
+                patched_represented_variables.append(
+                    self.represented_variables[idx].patch(
+                        other.represented_variables[idx]
+                    ).dict()
+                )
+        patched.update({
+            "name": self.name,
+            "label": other.label,
+            "notPseudonym": self.not_pseudonym,
+            "dataType": self.data_type,
+            "variableRole": self.variable_role,
+            "representedVariables": patched_represented_variables
+        })
+        if self.format is not None:
+            patched.update({"format": self.format})
+        if centralized_variable_definition:
+            patched.update({
+                'keyType': self.key_type.dict()
+            })
+        return Variable(**patched)
 
 
 class AttributeVariable(Variable):
-    def patch(self, other: 'Variable') -> 'Variable':
-        if other is None:
-            raise PatchingError('Can not delete Variable')
-
-        self.validate_patching_fields(other, with_name=True)
-        self.validate_represented_variables(other)
-        return self._patch_downstream(other)
+    ...
 
 
 class Metadata(CamelModel):
@@ -373,16 +361,6 @@ class Metadata(CamelModel):
         if self.sensitivity_level != other.sensitivity_level:
             raise PatchingError('Can not change sensitivityLevel')
 
-        sorted_self_attributes = sorted(
-            self.attribute_variables, key=lambda k: k.name
-        )
-        sorted_other_attributes = sorted(
-            other.attribute_variables, key=lambda k: k.name
-        )
-        patched_attribute_variables = [
-            sorted_self_attributes[0].patch(sorted_other_attributes[0]).dict(),
-            sorted_self_attributes[1].patch(sorted_other_attributes[1]).dict()
-        ]
         metadata_dict = {
             "name": self.name,
             "temporality": self.temporality,
@@ -399,7 +377,7 @@ class Metadata(CamelModel):
                     other.identifier_variables[0]
                 ).dict()
             ],
-            "attributeVariables": patched_attribute_variables,
+            "attributeVariables": self.attribute_variables,
             "temporalStatusDates": self.temporal_status_dates
         }
         if self.temporal_status_dates is None:

--- a/job_executor/model/metadata.py
+++ b/job_executor/model/metadata.py
@@ -273,24 +273,19 @@ class Variable(CamelModel):
                 f'dataType: {self.data_type} to {other.data_type},'
                 f'format: {self.format} to {other.format},'
                 f'variable_role: {self.variable_role} to '
-                f'{other.variable_role}'
+                f'{other.variable_role}\n'
             )
         if (
             with_name and
             self.name != other.name
         ):
-            message += f'shortName: {self.name} to {other.name},'
+            message += f'shortName: {self.name} to {other.name}\n'
         if (
             with_key_type and
-            self.key_type != other.key_type
+            self.key_type.name != other.key_type.name
         ):
-            message += f'unitType: ' \
-                       f'<shortName={self.key_type.name},' \
-                       f'name={self.key_type.label},' \
-                       f'description={self.key_type.description}> ' \
-                       f'to unitType: <shortName={other.key_type.name},' \
-                       f'name={other.key_type.label},' \
-                       f'description={other.key_type.description}> ' \
+            message += f'unitType.name: {self.key_type.name} ' \
+                       f'to {other.key_type.name}'
 
         if message:
             raise PatchingError(caption + message)

--- a/job_executor/model/metadata.py
+++ b/job_executor/model/metadata.py
@@ -295,7 +295,8 @@ class Variable(CamelModel):
             raise PatchingError('Can not change unitType')
         if len(self.represented_variables) != len(other.represented_variables):
             raise PatchingError(
-                'Can not add or delete represented variables. '
+                'Can not change the number of represented variables '
+                f'from {len(self.represented_variables)} to {len(other.represented_variables)} '
                 'Please check valueDomain.codeList field.'
             )
         if self.not_pseudonym != other.not_pseudonym:

--- a/job_executor/model/metadata.py
+++ b/job_executor/model/metadata.py
@@ -283,7 +283,7 @@ class Variable(CamelModel):
             with_key_type and
             self.key_type != other.key_type
         ):
-            message += f'name: {self.key_type} to {other.key_type},'
+            message += f'key_type: {self.key_type} to {other.key_type},'
 
         if message:
             raise PatchingError(caption + message)

--- a/job_executor/model/metadata.py
+++ b/job_executor/model/metadata.py
@@ -228,6 +228,11 @@ class Variable(CamelModel):
             # it is safe to only patch name and description fields.
             new_name = other.name
             only_patch_description = True
+            if self.key_type != other.key_type:
+                raise PatchingError(
+                    'Can not change keyType from '
+                    f'"{self.key_type}" to "{other.key_type}"'
+                )
             if (
                 self.data_type != other.data_type or
                 self.format != other.format or

--- a/job_executor/model/metadata.py
+++ b/job_executor/model/metadata.py
@@ -226,7 +226,6 @@ class Variable(CamelModel):
         if self.variable_role == "Measure" and self.key_type is not None:
             # Centralized variable definition was used,
             # it is safe to only patch name and description fields.
-            # patch name + description
             new_name = other.name
             only_patch_description = True
             if (

--- a/job_executor/worker/steps/dataset_transformer.py
+++ b/job_executor/worker/steps/dataset_transformer.py
@@ -82,7 +82,7 @@ def _represented_variables_from_code_list(description: str,
         for item in code_items if item.get('validUntil', None) is not None
     ]
     has_ongoing_time_period = any(
-        ['validUntil' not in item for item in code_items]
+        [item.get('validUntil', None) is None for item in code_items]
     )
     unique_dates = list(set(valid_from_dates + valid_until_dates))
     unique_dates.sort()

--- a/tests/resources/model/metadata/patch_unit_type/metadata.json
+++ b/tests/resources/model/metadata/patch_unit_type/metadata.json
@@ -1,0 +1,110 @@
+{
+  "name": "BEFOLKNING_MOR_FNR",
+  "populationDescription": "Bosatte i Norge",
+  "temporality": "FIXED",
+  "temporalCoverage": {
+    "start": -25567,
+    "stop": 18993
+  },
+  "identifierVariables": [
+    {
+      "name": "PERSONID_1",
+      "label": "Personidentifikator",
+      "representedVariables": [
+        {
+          "description": "Identifikator for person i RAIRD",
+          "validPeriod": {
+            "start": -25567,
+            "stop": 18993
+          },
+          "valueDomain": {
+            "description": "N/A",
+            "unitOfMeasure": "N/A"
+          }
+        }
+      ],
+      "dataType": "Long",
+      "variableRole": "Identifier",
+      "keyType": {
+        "name": "PERSON",
+        "label": "Person",
+        "description": "Statistisk enhet er person (individ, enkeltmenenske)"
+      },
+      "format": "RandomUInt48",
+      "notPseudonym": false
+    }
+  ],
+  "measureVariable": {
+    "name": "BEFOLKNING_MOR_FNR",
+    "label": "Fødselsnummer mor",
+    "representedVariables": [
+      {
+        "description": "Variabelen er konstruert fra mors fødselsnummer. Ment for bruk som koblingsnøkkel.",
+        "validPeriod": {
+          "start": -25567,
+          "stop": 18993
+        },
+        "valueDomain": {
+          "description": "N/A",
+          "unitOfMeasure": "N/A"
+        }
+      }
+    ],
+    "dataType": "Long",
+    "variableRole": "Measure",
+    "keyType": {
+      "name": "PERSON",
+      "label": "Person",
+      "description": "Statistisk enhet er person (individ, enkeltmenenske)"
+    },
+    "format": "RandomUInt48",
+    "notPseudonym": false
+  },
+  "subjectFields": [
+    "Befolkning"
+  ],
+  "languageCode": "no",
+  "attributeVariables": [
+    {
+      "name": "STOP",
+      "label": "Stoppdato",
+      "representedVariables": [
+        {
+          "description": "Stoppdato/sluttdato for hendelsen",
+          "validPeriod": {
+            "start": -25567,
+            "stop": 18993
+          },
+          "valueDomain": {
+            "description": "N/A",
+            "unitOfMeasure": "N/A"
+          }
+        }
+      ],
+      "dataType": "Instant",
+      "variableRole": "Stop",
+      "notPseudonym": true
+    },
+    {
+      "name": "START",
+      "label": "Startdato",
+      "representedVariables": [
+        {
+          "description": "Startdato/måletidspunktet for hendelsen",
+          "validPeriod": {
+            "start": -25567,
+            "stop": 18993
+          },
+          "valueDomain": {
+            "description": "N/A",
+            "unitOfMeasure": "N/A"
+          }
+        }
+      ],
+      "dataType": "Instant",
+      "variableRole": "Start",
+      "notPseudonym": true
+    }
+  ],
+  "sensitivityLevel": "PERSON_GENERAL"
+}

--- a/tests/resources/model/metadata/patch_unit_type/patched_metadata.json
+++ b/tests/resources/model/metadata/patch_unit_type/patched_metadata.json
@@ -1,0 +1,110 @@
+{
+  "name": "BEFOLKNING_MOR_FNR",
+  "populationDescription": "Bosatte i Norge",
+  "temporality": "FIXED",
+  "temporalCoverage": {
+    "start": -25567,
+    "stop": 18993
+  },
+  "identifierVariables": [
+    {
+      "name": "PERSONID_1",
+      "label": "Personidentifikator",
+      "representedVariables": [
+        {
+          "description": "Identifikator for person i RAIRD",
+          "validPeriod": {
+            "start": -25567,
+            "stop": 18993
+          },
+          "valueDomain": {
+            "description": "N/A",
+            "unitOfMeasure": "N/A"
+          }
+        }
+      ],
+      "dataType": "Long",
+      "variableRole": "Identifier",
+      "keyType": {
+        "name": "PERSON",
+        "label": "Person",
+        "description": "Statistisk enhet er person (individ, enkeltmenenske)"
+      },
+      "format": "RandomUInt48",
+      "notPseudonym": false
+    }
+  ],
+  "measureVariable": {
+    "name": "BEFOLKNING_MOR_FNR_new_name",
+    "label": "Fødselsnummer mor",
+    "representedVariables": [
+      {
+        "description": "new description",
+        "validPeriod": {
+          "start": -25567,
+          "stop": 18993
+        },
+        "valueDomain": {
+          "description": "N/A",
+          "unitOfMeasure": "N/A"
+        }
+      }
+    ],
+    "dataType": "Long",
+    "variableRole": "Measure",
+    "keyType": {
+      "name": "PERSON",
+      "label": "Person",
+      "description": "Statistisk enhet er person (individ, enkeltmenenske)"
+    },
+    "format": "RandomUInt48",
+    "notPseudonym": false
+  },
+  "subjectFields": [
+    "Befolkning"
+  ],
+  "languageCode": "no",
+  "attributeVariables": [
+    {
+      "name": "START",
+      "label": "Startdato",
+      "representedVariables": [
+        {
+          "description": "Startdato/måletidspunktet for hendelsen",
+          "validPeriod": {
+            "start": -25567,
+            "stop": 18993
+          },
+          "valueDomain": {
+            "description": "N/A",
+            "unitOfMeasure": "N/A"
+          }
+        }
+      ],
+      "dataType": "Instant",
+      "variableRole": "Start",
+      "notPseudonym": true
+    },
+    {
+      "name": "STOP",
+      "label": "Stoppdato",
+      "representedVariables": [
+        {
+          "description": "Stoppdato/sluttdato for hendelsen",
+          "validPeriod": {
+            "start": -25567,
+            "stop": 18993
+          },
+          "valueDomain": {
+            "description": "N/A",
+            "unitOfMeasure": "N/A"
+          }
+        }
+      ],
+      "dataType": "Instant",
+      "variableRole": "Stop",
+      "notPseudonym": true
+    }
+  ],
+  "sensitivityLevel": "PERSON_GENERAL"
+}

--- a/tests/resources/model/metadata/patch_unit_type/patched_metadata.json
+++ b/tests/resources/model/metadata/patch_unit_type/patched_metadata.json
@@ -66,26 +66,6 @@
   "languageCode": "no",
   "attributeVariables": [
     {
-      "name": "START",
-      "label": "Startdato",
-      "representedVariables": [
-        {
-          "description": "Startdato/måletidspunktet for hendelsen",
-          "validPeriod": {
-            "start": -25567,
-            "stop": 18993
-          },
-          "valueDomain": {
-            "description": "N/A",
-            "unitOfMeasure": "N/A"
-          }
-        }
-      ],
-      "dataType": "Instant",
-      "variableRole": "Start",
-      "notPseudonym": true
-    },
-    {
       "name": "STOP",
       "label": "Stoppdato",
       "representedVariables": [
@@ -103,6 +83,26 @@
       ],
       "dataType": "Instant",
       "variableRole": "Stop",
+      "notPseudonym": true
+    },
+    {
+      "name": "START",
+      "label": "Startdato",
+      "representedVariables": [
+        {
+          "description": "Startdato/måletidspunktet for hendelsen",
+          "validPeriod": {
+            "start": -25567,
+            "stop": 18993
+          },
+          "valueDomain": {
+            "description": "N/A",
+            "unitOfMeasure": "N/A"
+          }
+        }
+      ],
+      "dataType": "Instant",
+      "variableRole": "Start",
       "notPseudonym": true
     }
   ],

--- a/tests/resources/model/metadata/patch_unit_type/patched_metadata.json
+++ b/tests/resources/model/metadata/patch_unit_type/patched_metadata.json
@@ -39,7 +39,7 @@
     "label": "Fødselsnummer mor new label",
     "representedVariables": [
       {
-        "description": "new description",
+        "description": "Variabelen er konstruert fra mors fødselsnummer. Ment for bruk som koblingsnøkkel.",
         "validPeriod": {
           "start": -25567,
           "stop": 18993

--- a/tests/resources/model/metadata/patch_unit_type/patched_metadata.json
+++ b/tests/resources/model/metadata/patch_unit_type/patched_metadata.json
@@ -35,8 +35,8 @@
     }
   ],
   "measureVariable": {
-    "name": "BEFOLKNING_MOR_FNR_new_name",
-    "label": "Fødselsnummer mor",
+    "name": "BEFOLKNING_MOR_FNR",
+    "label": "Fødselsnummer mor new label",
     "representedVariables": [
       {
         "description": "new description",

--- a/tests/resources/model/metadata/patch_unit_type/updated_metadata.json
+++ b/tests/resources/model/metadata/patch_unit_type/updated_metadata.json
@@ -39,7 +39,7 @@
     "label": "Fødselsnummer mor new label",
     "representedVariables": [
       {
-        "description": "new description",
+        "description": "Variabelen er konstruert fra mors fødselsnummer. Ment for bruk som koblingsnøkkel.",
         "validPeriod": {
           "start": -25567,
           "stop": 18993

--- a/tests/resources/model/metadata/patch_unit_type/updated_metadata.json
+++ b/tests/resources/model/metadata/patch_unit_type/updated_metadata.json
@@ -35,8 +35,8 @@
     }
   ],
   "measureVariable": {
-    "name": "BEFOLKNING_MOR_FNR_new_name",
-    "label": "Fødselsnummer mor",
+    "name": "BEFOLKNING_MOR_FNR",
+    "label": "Fødselsnummer mor new label",
     "representedVariables": [
       {
         "description": "new description",

--- a/tests/resources/model/metadata/patch_unit_type/updated_metadata.json
+++ b/tests/resources/model/metadata/patch_unit_type/updated_metadata.json
@@ -1,0 +1,110 @@
+{
+  "name": "BEFOLKNING_MOR_FNR",
+  "populationDescription": "Bosatte i Norge",
+  "temporality": "FIXED",
+  "temporalCoverage": {
+    "start": -25567,
+    "stop": 18993
+  },
+  "identifierVariables": [
+    {
+      "name": "PERSONID_1",
+      "label": "Personidentifikator",
+      "representedVariables": [
+        {
+          "description": "Identifikator for person i RAIRD",
+          "validPeriod": {
+            "start": -25567,
+            "stop": 18993
+          },
+          "valueDomain": {
+            "description": "N/A",
+            "unitOfMeasure": "N/A"
+          }
+        }
+      ],
+      "dataType": "Long",
+      "variableRole": "Identifier",
+      "keyType": {
+        "name": "PERSON",
+        "label": "Person",
+        "description": "Statistisk enhet er person (individ, enkeltmenenske)"
+      },
+      "format": "RandomUInt48",
+      "notPseudonym": false
+    }
+  ],
+  "measureVariable": {
+    "name": "BEFOLKNING_MOR_FNR_new_name",
+    "label": "Fødselsnummer mor",
+    "representedVariables": [
+      {
+        "description": "new description",
+        "validPeriod": {
+          "start": -25567,
+          "stop": 18993
+        },
+        "valueDomain": {
+          "description": "N/A",
+          "unitOfMeasure": "N/A"
+        }
+      }
+    ],
+    "dataType": "Long",
+    "variableRole": "Measure",
+    "keyType": {
+      "name": "PERSON",
+      "label": "Person",
+      "description": "Statistisk enhet er person (individ, enkeltmenenske)"
+    },
+    "format": "RandomUInt48",
+    "notPseudonym": false
+  },
+  "subjectFields": [
+    "Befolkning"
+  ],
+  "languageCode": "no",
+  "attributeVariables": [
+    {
+      "name": "STOP",
+      "label": "Stoppdato",
+      "representedVariables": [
+        {
+          "description": "Stoppdato/sluttdato for hendelsen",
+          "validPeriod": {
+            "start": -25567,
+            "stop": 18993
+          },
+          "valueDomain": {
+            "description": "N/A",
+            "unitOfMeasure": "N/A"
+          }
+        }
+      ],
+      "dataType": "Instant",
+      "variableRole": "Stop",
+      "notPseudonym": true
+    },
+    {
+      "name": "START",
+      "label": "Startdato",
+      "representedVariables": [
+        {
+          "description": "Startdato/måletidspunktet for hendelsen",
+          "validPeriod": {
+            "start": -25567,
+            "stop": 18993
+          },
+          "valueDomain": {
+            "description": "N/A",
+            "unitOfMeasure": "N/A"
+          }
+        }
+      ],
+      "dataType": "Instant",
+      "variableRole": "Start",
+      "notPseudonym": true
+    }
+  ],
+  "sensitivityLevel": "PERSON_GENERAL"
+}

--- a/tests/resources/model/metadata/patched_metadata.json
+++ b/tests/resources/model/metadata/patched_metadata.json
@@ -55,15 +55,15 @@
       {
         "variableRole": "Start",
         "name": "START",
-        "label": "new value",
+        "label": "Startdato",
         "notPseudonym": true,
         "dataType": "Instant",
         "representedVariables": [
           {
-            "description": "new value",
+            "description": "Startdato/m\u00e5letidspunktet for hendelsen",
             "validPeriod": { "start": -25567, "stop": 18628 },
             "valueDomain": {
-              "description": "new value",
+              "description": "Dato oppgitt i dager siden 1970-01-01",
               "unitOfMeasure": "N/A"
             }
           }
@@ -77,10 +77,10 @@
         "dataType": "Instant",
         "representedVariables": [
           {
-            "description": "new value",
+            "description": "Stoppdato/sluttdato for hendelsen",
             "validPeriod": { "start": -25567, "stop": 18628 },
             "valueDomain": {
-              "description": "new value",
+              "description": "Dato oppgitt i dager siden 1970-01-01",
               "unitOfMeasure": "N/A"
             }
           }

--- a/tests/resources/model/metadata/patched_metadata.json
+++ b/tests/resources/model/metadata/patched_metadata.json
@@ -10,15 +10,15 @@
       {
         "variableRole": "Identifier",
         "name": "PERSON",
-        "label": "new value",
+        "label": "Personidentifikator",
         "notPseudonym": false,
         "dataType": "String",
         "representedVariables": [
           {
-            "description": "new value",
+            "description": "Identifikator for person i Microdata",
             "validPeriod": { "start": -25567, "stop": 18628 },
             "valueDomain": {
-              "description": "new value",
+              "description": "Pseudonymisert personnummer",
               "unitOfMeasure": "N/A"
             }
           }
@@ -26,8 +26,8 @@
         "format": "RandomUInt48",
         "keyType": {
           "name": "PERSON",
-          "label": "new value",
-          "description": "new value"
+          "label": "Person",
+          "description": "Statistisk enhet er person (individ, enkeltmenenske)"
         }
       }
     ],

--- a/tests/resources/model/metadata/updated_metadata.json
+++ b/tests/resources/model/metadata/updated_metadata.json
@@ -40,7 +40,7 @@
       "representedVariables": [
         {
           "description": "new value",
-          "validPeriod": { "start": null },
+          "validPeriod": { "start": -25567 },
           "valueDomain": {
             "codeList": [
               { "category": "Mann", "code": "1" },

--- a/tests/resources/worker/steps/transformer/input/UTDANNING.json
+++ b/tests/resources/worker/steps/transformer/input/UTDANNING.json
@@ -141,7 +141,8 @@
                 "value": "Grunnskole"
               }
             ],
-            "validFrom": "1926-01-01"
+            "validFrom": "1926-01-01",
+            "validUntil": null
           },
           {
             "code": "2",
@@ -151,7 +152,8 @@
                 "value": "Videregående skole"
               }
             ],
-            "validFrom": "1926-01-01"
+            "validFrom": "1926-01-01",
+            "validUntil": null
           },
           {
             "code": "3",
@@ -161,7 +163,8 @@
                 "value": "Bachelorgrad"
               }
             ],
-            "validFrom": "1926-01-01"
+            "validFrom": "1926-01-01",
+            "validUntil": null
           },
           {
             "code": "4",
@@ -171,7 +174,8 @@
                 "value": "Mastergrad"
               }
             ],
-            "validFrom": "1926-01-01"
+            "validFrom": "1926-01-01",
+            "validUntil": null
           },
           {
             "code": "5",
@@ -181,7 +185,8 @@
                 "value": "Doktorgrad"
               }
             ],
-            "validFrom": "1926-01-01"
+            "validFrom": "1926-01-01",
+            "validUntil": null
           }
         ]
       },

--- a/tests/unit/model/test_metadata.py
+++ b/tests/unit/model/test_metadata.py
@@ -19,6 +19,10 @@ METADATA_IN_DATASTORE = load_json(f'{TEST_DIR}/metadata.json')
 UPDATED_METADATA = load_json(f'{TEST_DIR}/updated_metadata.json')
 PATCHED_METADATA = load_json(f'{TEST_DIR}/patched_metadata.json')
 
+PATCH_UNIT_TYPE_METADATA_IN_DATASTORE = load_json(f'{TEST_DIR}/patch_unit_type/metadata.json')
+PATCH_UNIT_TYPE_UPDATED_METADATA = load_json(f'{TEST_DIR}/patch_unit_type/updated_metadata.json')
+PATCH_UNIT_TYPE_PATCHED_METADATA = load_json(f'{TEST_DIR}/patch_unit_type/patched_metadata.json')
+
 
 def setup_module():
 
@@ -57,3 +61,10 @@ def test_patch():
     updated_metadata = Metadata(**UPDATED_METADATA)
     patched_metadata = metadata_in_datastore.patch(updated_metadata)
     assert patched_metadata.dict(by_alias=True) == PATCHED_METADATA
+
+
+def test_patch_change_name_desc_when_measure_has_a_unit_type():
+    metadata_in_datastore = Metadata(**PATCH_UNIT_TYPE_METADATA_IN_DATASTORE)
+    updated_metadata = Metadata(**PATCH_UNIT_TYPE_UPDATED_METADATA)
+    patched_metadata = metadata_in_datastore.patch(updated_metadata)
+    assert patched_metadata.dict(by_alias=True) == PATCH_UNIT_TYPE_PATCHED_METADATA

--- a/tests/unit/model/test_metadata.py
+++ b/tests/unit/model/test_metadata.py
@@ -67,4 +67,5 @@ def test_patch_change_name_desc_when_measure_has_a_unit_type():
     metadata_in_datastore = Metadata(**PATCH_UNIT_TYPE_METADATA_IN_DATASTORE)
     updated_metadata = Metadata(**PATCH_UNIT_TYPE_UPDATED_METADATA)
     patched_metadata = metadata_in_datastore.patch(updated_metadata)
-    assert patched_metadata.dict(by_alias=True) == PATCH_UNIT_TYPE_PATCHED_METADATA
+    assert patched_metadata.dict(by_alias=True) == \
+           PATCH_UNIT_TYPE_PATCHED_METADATA


### PR DESCRIPTION
Implementation changed as follows:
- if variable role is "Identifier" return the same object
- if variable role is "Measure" and "keyType" is used, then allow only for changing the name and represented variable's description, throw an error if any other field was attempted to be changed
