### PR TITLE
Format JSON when saving datastore files

### DIFF
--- a/job_executor/adapter/local_storage.py
+++ b/job_executor/adapter/local_storage.py
@@ -25,9 +25,12 @@ def _read_json(file_path: str) -> dict:
         return json.load(f)
 
 
-def _write_json(content: dict, file_path: str) -> None:
+def _write_json(
+    content: dict,
+    file_path: Union[str, Path],
+    indent: int = None) -> None:
     with open(file_path, 'w', encoding='utf-8') as f:
-        json.dump(content, f)
+        json.dump(content, f, indent=indent)
 
 
 def _get_parquet_path(directory: str, dataset_name: str) -> str:
@@ -94,7 +97,8 @@ def write_data_versions(data_versions: dict, version: str):
     file_version = '_'.join(version.split('_')[:-1])
     _write_json(
         data_versions,
-        f'{DATASTORE_DIR}/datastore/data_versions__{file_version}.json'
+        f'{DATASTORE_DIR}/datastore/data_versions__{file_version}.json',
+        indent=2
     )
 
 
@@ -113,7 +117,8 @@ def write_draft_version(draft_version: dict) -> None:
     """
     _write_json(
         draft_version,
-        f'{DATASTORE_DIR}/datastore/draft_version.json'
+        f'{DATASTORE_DIR}/datastore/draft_version.json',
+        indent=2
     )
 
 
@@ -134,7 +139,8 @@ def write_datastore_versions(datastore_versions: dict) -> None:
     """
     _write_json(
         datastore_versions,
-        f'{DATASTORE_DIR}/datastore/datastore_versions.json'
+        f'{DATASTORE_DIR}/datastore/datastore_versions.json',
+        indent=2
     )
 
 

--- a/job_executor/adapter/local_storage.py
+++ b/job_executor/adapter/local_storage.py
@@ -322,7 +322,6 @@ def delete_working_dir_file(file_name: str) -> None:
     Intended to clean up left-over files.
     Raises a LocalStorageError if filepath is not in
     the working directory.
-    
     * file_name: str - name of temporary file
     """
     if not file_name.startswith(WORKING_DIR):
@@ -357,14 +356,15 @@ def save_temporary_backup() -> None:
     if os.path.isdir(tmp_dir):
         raise LocalStorageError('tmp directory already exists')
     os.mkdir(tmp_dir)
-    with open(tmp_dir / 'draft_version.json', 'w', encoding='utf-8') as f:
-        json.dump(draft_version, f)
-    with open(
-        tmp_dir / 'metadata_all__DRAFT.json', 'w', encoding='utf-8'
-    ) as f:
-        json.dump(metadata_all_draft, f)
-    with open(tmp_dir / 'datastore_versions.json', 'w', encoding='utf-8') as f:
-        json.dump(datastore_versions, f)
+    _write_json(
+        draft_version, tmp_dir / 'draft_version.json', indent=2
+    )
+    _write_json(
+        metadata_all_draft, tmp_dir / 'metadata_all__DRAFT.json'
+    )
+    _write_json(
+        datastore_versions, tmp_dir / 'datastore_versions.json', indent=2
+    )
 
 
 def restore_from_temporary_backup() -> Union[str, None, LocalStorageError]:


### PR DESCRIPTION
Formats `data_versions*`, `datastore_versions.json` and `draft_version.json` with indentation.
`metadata_all*` are too big anyway so no formatting here.