### PR TITLE
Bugfix corrupt parquet

### DIFF
--- a/job_executor/worker/steps/dataset_pseudonymizer.py
+++ b/job_executor/worker/steps/dataset_pseudonymizer.py
@@ -120,17 +120,16 @@ def _pseudonymize(
     )
 
     # Handle regular columns
-    if "start_year" in input_dataset.schema.names:
-        columns.append(
-            _get_regular_column(input_dataset, "start_year", pyarrow.string())
-        )
-
     columns.append(
         _get_regular_column(input_dataset, "start_epoch_days", pyarrow.int16())
     )
     columns.append(
         _get_regular_column(input_dataset, "stop_epoch_days", pyarrow.int16())
     )
+    if "start_year" in input_dataset.schema.names:
+        columns.append(
+            _get_regular_column(input_dataset, "start_year", pyarrow.string())
+        )
 
     pseudonymized_table = pyarrow.Table.from_arrays(
         columns, input_dataset.schema.names

--- a/tests/unit/worker/steps/test_dataset_pseudonymizer.py
+++ b/tests/unit/worker/steps/test_dataset_pseudonymizer.py
@@ -34,14 +34,14 @@ INPUT_TABLE_START_YEAR = pyarrow.Table.from_pydict(
     {
         "unit_id": UNIT_ID_INPUT,
         "value": UNIT_ID_INPUT,
-        "start_year": pyarrow.array(
-            [str(year) for year in [2020] * TABLE_SIZE]
-        ),
         "start_epoch_days": pyarrow.array(
             [18200] * TABLE_SIZE, type=pyarrow.int16()
         ),
         "stop_epoch_days": pyarrow.array(
             [18201] * TABLE_SIZE, type=pyarrow.int16()
+        ),
+        "start_year": pyarrow.array(
+            [str(year) for year in [2020] * TABLE_SIZE]
         ),
     }
 )
@@ -63,14 +63,14 @@ EXPECTED_TABLE_START_YEAR = pyarrow.Table.from_pydict(
     {
         "unit_id": UNIT_ID_PSEUDONYMIZED,
         "value": UNIT_ID_INPUT,
-        "start_year": pyarrow.array(
-            [str(year) for year in [2020] * TABLE_SIZE]
-        ),
         "start_epoch_days": pyarrow.array(
             [18200] * TABLE_SIZE, type=pyarrow.int16()
         ),
         "stop_epoch_days": pyarrow.array(
             [18201] * TABLE_SIZE, type=pyarrow.int16()
+        ),
+        "start_year": pyarrow.array(
+            [str(year) for year in [2020] * TABLE_SIZE]
         ),
     }
 )


### PR DESCRIPTION
The pseudonymizer is opinionated to the order of the columns in the parquet file. This is something we might consider changing in the future, but for now the bug is fixed by adjusting the order to fit the microdata-tools output format for validated parquet