### PR TITLE
Expand model with TemporalEnd

### DIFF
--- a/job_executor/model/metadata.py
+++ b/job_executor/model/metadata.py
@@ -1,8 +1,7 @@
 from typing import List, Optional, Union
 
-from job_executor.model.camelcase_model import CamelModel
 from job_executor.exception import PatchingError, MetadataException
-
+from job_executor.model.camelcase_model import CamelModel
 
 DATA_TYPES_MAPPING = {
     "STRING": "String",
@@ -277,6 +276,11 @@ class AttributeVariable(Variable):
     ...
 
 
+class TemporalEnd(CamelModel):
+    description: str
+    successors: Optional[List[str]] = None
+
+
 class Metadata(CamelModel):
     name: str
     temporality: str
@@ -289,6 +293,7 @@ class Metadata(CamelModel):
     identifier_variables: List[IdentifierVariable]
     attribute_variables: List[AttributeVariable]
     temporal_status_dates: Optional[List[int]] = None
+    temporal_end: Optional[TemporalEnd] = None
 
     def get_identifier_key_type_name(self):
         return self.identifier_variables[0].get_key_type_name()
@@ -337,6 +342,10 @@ class Metadata(CamelModel):
             "attributeVariables": self.attribute_variables,
             "temporalStatusDates": self.temporal_status_dates,
         }
+        if other.temporal_end is not None:
+            metadata_dict["temporalEnd"] = other.temporal_end.model_dump(
+                by_alias=True, exclude_none=True
+            )
         if self.temporal_status_dates is None:
             del metadata_dict["temporalStatusDates"]
         return Metadata(**metadata_dict)

--- a/job_executor/worker/steps/dataset_transformer.py
+++ b/job_executor/worker/steps/dataset_transformer.py
@@ -270,6 +270,18 @@ def _transform_attribute_variables(metadata: dict, start: str, stop: str):
     ]
 
 
+def _transform_temporal_end(temporal_end: dict):
+    temporal_end_result = {
+        "description": _get_norwegian_text(temporal_end["description"])
+    }
+    if (
+        temporal_end.get("successors") is not None
+        and len(temporal_end["successors"]) > 0
+    ):
+        temporal_end_result["successors"] = temporal_end["successors"]
+    return temporal_end_result
+
+
 def _transform_metadata(metadata: Dict) -> Dict:
     logger.info("Transforming metadata")
     # These values are found by going through the data file.
@@ -307,6 +319,10 @@ def _transform_metadata(metadata: Dict) -> Dict:
     if metadata["temporalityType"] == "STATUS":
         transformed["temporalStatusDates"] = _transform_temporal_status_dates(
             metadata["dataRevision"].get("temporalStatusDates", None)
+        )
+    if metadata["dataRevision"].get("temporalEnd") is not None:
+        transformed["temporalEnd"] = _transform_temporal_end(
+            metadata["dataRevision"]["temporalEnd"]
         )
     logger.info("Finished transformation")
     return transformed

--- a/poetry.lock
+++ b/poetry.lock
@@ -351,13 +351,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "idna"
-version = "3.7"
+version = "3.8"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 files = [
-    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
-    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
+    {file = "idna-3.8-py3-none-any.whl", hash = "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac"},
+    {file = "idna-3.8.tar.gz", hash = "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"},
 ]
 
 [[package]]
@@ -373,13 +373,13 @@ files = [
 
 [[package]]
 name = "microdata-tools"
-version = "0.18.0"
+version = "1.0.0"
 description = "Tools for the microdata.no platform"
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "microdata_tools-0.18.0-py3-none-any.whl", hash = "sha256:ed211d4c48ba953a6f1576c3c2f4283c39d39a5144223f33829a2dcbd36f795c"},
-    {file = "microdata_tools-0.18.0.tar.gz", hash = "sha256:368c3ca2ae16dbeb98f72b09322c3031270bb7a5897e2a3ab68fd8dca0c7c2a2"},
+    {file = "microdata_tools-1.0.0-py3-none-any.whl", hash = "sha256:3d87a1af4bfed044aa165330b52722b4c77f8d73bf3faf285021260c08d0e5e5"},
+    {file = "microdata_tools-1.0.0.tar.gz", hash = "sha256:9a0f7728b432407aaa1a15b4463c2e461120b698acf999f717ea3fde2b526628"},
 ]
 
 [package.dependencies]
@@ -936,4 +936,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "4e6a37e7426ca2c624e8d5d5aa1d74235b6d323fbcc676b453180b9df2da268c"
+content-hash = "fb39ec31bfd160e6f05cd49750c8c735cf3f101fee61a4331d0a8dfd9cf0ee88"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ pyarrow = "^15.0.0"
 pydantic = "^2.6.1"
 requests = "^2.32.0"
 pandas = "^2.2.1"
-microdata-tools = "0.18.0"
 urllib3 = "^2.2.2"
+microdata-tools = "^1.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.1"

--- a/tests/resources/datastores/TEST_DATASTORE_input/BOSTED/BOSTED.json
+++ b/tests/resources/datastores/TEST_DATASTORE_input/BOSTED/BOSTED.json
@@ -22,8 +22,7 @@
         "languageCode": "no",
         "value": "Første publisering."
       }
-    ],
-    "temporalEndOfSeries": false
+    ]
   },
   "identifierVariables": [
     {

--- a/tests/resources/datastores/TEST_DATASTORE_input/INNTEKT/INNTEKT.json
+++ b/tests/resources/datastores/TEST_DATASTORE_input/INNTEKT/INNTEKT.json
@@ -39,8 +39,7 @@
         "languageCode": "no",
         "value": "Oppdaterte data"
       }
-    ],
-    "temporalEndOfSeries": false
+    ]
   },
   "identifierVariables": [
     {

--- a/tests/resources/datastores/TEST_DATASTORE_input/KJOENN/KJOENN.json
+++ b/tests/resources/datastores/TEST_DATASTORE_input/KJOENN/KJOENN.json
@@ -33,8 +33,7 @@
         "languageCode": "no",
         "value": "Første publisering."
       }
-    ],
-    "temporalEndOfSeries": false
+    ]
   },
   "identifierVariables": [
     {

--- a/tests/resources/datastores/TEST_DATASTORE_input/KOMMUNE_FOLKETALL/KOMMUNE_FOLKETALL.json
+++ b/tests/resources/datastores/TEST_DATASTORE_input/KOMMUNE_FOLKETALL/KOMMUNE_FOLKETALL.json
@@ -7,8 +7,7 @@
 		[{"languageCode": "no", "value": "BEFOLKNING"}]
 	],
 	"dataRevision": {
-		"description": [{"languageCode": "no","value": "Første publisering."}],
-		"temporalEndOfSeries": false
+		"description": [{"languageCode": "no","value": "Første publisering."}]
 	},
 	"identifierVariables": [{"unitType": "KOMMUNE"}],
 	"measureVariables": [

--- a/tests/resources/datastores/TEST_DATASTORE_input/KOMMUNE_HOYESTE_PUNKT/KOMMUNE_HOYESTE_PUNKT.json
+++ b/tests/resources/datastores/TEST_DATASTORE_input/KOMMUNE_HOYESTE_PUNKT/KOMMUNE_HOYESTE_PUNKT.json
@@ -7,8 +7,7 @@
 		[{"languageCode": "no", "value": "BEFOLKNING"}]
 	],
 	"dataRevision": {
-		"description": [{"languageCode": "no","value": "Første publisering."}],
-		"temporalEndOfSeries": false
+		"description": [{"languageCode": "no","value": "Første publisering."}]
 	},
 	"identifierVariables": [{"unitType": "KOMMUNE"}],
 	"measureVariables": [

--- a/tests/resources/datastores/TEST_DATASTORE_input/UTDANNING/UTDANNING.json
+++ b/tests/resources/datastores/TEST_DATASTORE_input/UTDANNING/UTDANNING.json
@@ -18,8 +18,7 @@
         ]
       ],
     "dataRevision": {
-      "description": [{"languageCode": "no","value": "Første publisering."}],
-      "temporalEndOfSeries": false
+      "description": [{"languageCode": "no","value": "Første publisering."}]
     },
     "identifierVariables": [{"unitType": "PERSON"}],
     "measureVariables": [

--- a/tests/resources/worker/steps/transformer/expected/KREFTREG_DS_described.json
+++ b/tests/resources/worker/steps/transformer/expected/KREFTREG_DS_described.json
@@ -108,5 +108,8 @@
         17167,
         17532,
         17897
-    ]
+    ],
+    "temporalEnd": {
+        "description": "Variabelen blir ikke lenger oppdatert"
+    }
 }

--- a/tests/resources/worker/steps/transformer/expected/KREFTREG_DS_enumerated.json
+++ b/tests/resources/worker/steps/transformer/expected/KREFTREG_DS_enumerated.json
@@ -202,5 +202,12 @@
         17167,
         17532,
         17897
-    ]
+    ],
+    "temporalEnd": {
+        "description": "Variabelen blir ikke lenger oppdatert",
+        "successors": [
+            "KREFTREG_DS_1",
+            "KREFTREG_DS_2"
+        ]
+    }
 }

--- a/tests/resources/worker/steps/transformer/expected/UTDANNING.json
+++ b/tests/resources/worker/steps/transformer/expected/UTDANNING.json
@@ -128,5 +128,8 @@
         8035,
         8401,
         8766
-    ]
+    ],
+    "temporalEnd": {
+        "description": "Variabelen blir ikke lenger oppdatert"
+    }
 }

--- a/tests/resources/worker/steps/transformer/expected/UTDANNING_PATCH.json
+++ b/tests/resources/worker/steps/transformer/expected/UTDANNING_PATCH.json
@@ -121,5 +121,12 @@
             ]
         }
     ],
-    "temporalStatusDates": null
+    "temporalStatusDates": null,
+    "temporalEnd": {
+        "description": "Variabelen blir ikke lenger oppdatert",
+        "successors": [
+            "UTDANNING_1",
+            "UTDANNING_2"
+        ]
+    }
 }

--- a/tests/resources/worker/steps/transformer/input_data/KREFTREG_DS_described.json
+++ b/tests/resources/worker/steps/transformer/input_data/KREFTREG_DS_described.json
@@ -20,8 +20,10 @@
       "temporalCoverageStart": "2015-01-01",
       "temporalCoverageLatest": "2020-12-31",
       "temporalStatusDates": ["2015-01-01", "2016-01-01", "2017-01-01", "2018-01-01", "2019-01-01"],
-      "temporalEndOfSeries": false
-    },
+      "temporalEnd": {
+        "description": [{"languageCode": "no","value": "Variabelen blir ikke lenger oppdatert"}]
+      }
+    },  
     "measureVariables": [
         {
             "shortName": "KREFTREG_DS",

--- a/tests/resources/worker/steps/transformer/input_data/KREFTREG_DS_enumerated.json
+++ b/tests/resources/worker/steps/transformer/input_data/KREFTREG_DS_enumerated.json
@@ -20,7 +20,12 @@
       "temporalCoverageStart": "2015-01-01",
       "temporalCoverageLatest": "2020-12-31",
       "temporalStatusDates": ["2015-01-01", "2016-01-01", "2017-01-01", "2018-01-01", "2019-01-01"],
-      "temporalEndOfSeries": false
+      "temporalEnd": {
+        "description": [{"languageCode": "no", "value": "Variabelen blir ikke lenger oppdatert"}],
+        "successors": [ 
+            "KREFTREG_DS_1", "KREFTREG_DS_2"
+        ]
+      }
     },
     "measureVariables": [
       {

--- a/tests/resources/worker/steps/transformer/input_data/UTDANNING.json
+++ b/tests/resources/worker/steps/transformer/input_data/UTDANNING.json
@@ -1,134 +1,141 @@
 {
-  "temporalityType": "STATUS",
-  "sensitivityLevel": "PERSON_GENERAL",
-  "populationDescription": [
-    {
-      "languageCode": "no",
-      "value": "Personer med utdannelse i Norge"
-    }
-  ],
-  "subjectFields": [
-    [
-      {
-        "value": "BEFOLKNING",
-        "languageCode": "no"
-      }
-    ],
-    [
-      {
-        "value": "UTDANNING",
-        "languageCode": "no"
-      }
-    ]
-  ],
-  "spatialCoverageDescription": [
-    {
-      "languageCode": "no",
-      "value": "Norge"
-    }
-  ],
-  "dataRevision": {
-    "description": [
-      {
-        "languageCode": "no",
-        "value": "Første publisering."
-      }
-    ],
-    "temporalEndOfSeries": false,
-    "temporalCoverageStart": "1990-01-01",
-    "temporalCoverageLatest": "1994-01-01",
-    "temporalStatusDates": [
-      "1990-01-01",
-      "1991-01-01",
-      "1992-01-01",
-      "1993-01-01",
-      "1994-01-01"
-    ]
-  },
-  "measureVariables": [
-    {
-      "name": [
+    "temporalityType": "STATUS",
+    "sensitivityLevel": "PERSON_GENERAL",
+    "populationDescription": [
         {
-          "languageCode": "no",
-          "value": "Utdanning"
-        }
-      ],
-      "description": [
-        {
-          "languageCode": "no",
-          "value": "Utdanningsnivå for person"
-        }
-      ],
-      "subjectFields": [
-        [
-          {
             "languageCode": "no",
-            "value": "Testdata"
-          }
+            "value": "Personer med utdannelse i Norge"
+        }
+    ],
+    "subjectFields": [
+        [
+            {
+                "value": "BEFOLKNING",
+                "languageCode": "no"
+            }
+        ],
+        [
+            {
+                "value": "UTDANNING",
+                "languageCode": "no"
+            }
         ]
-      ],
-      "dataType": "STRING",
-      "valueDomain": {
-        "codeList": [
-          {
-            "code": "1",
-            "categoryTitle": [
-              {
+    ],
+    "spatialCoverageDescription": [
+        {
+            "languageCode": "no",
+            "value": "Norge"
+        }
+    ],
+    "dataRevision": {
+        "description": [
+            {
                 "languageCode": "no",
-                "value": "Grunnskole"
-              }
-            ],
-            "validFrom": "1926-01-01",
-            "validUntil": null
-          },
-          {
-            "code": "2",
-            "categoryTitle": [
-              {
-                "languageCode": "no",
-                "value": "Videregående skole"
-              }
-            ],
-            "validFrom": "1926-01-01",
-            "validUntil": null
-          },
-          {
-            "code": "3",
-            "categoryTitle": [
-              {
-                "languageCode": "no",
-                "value": "Bachelorgrad"
-              }
-            ],
-            "validFrom": "1926-01-01",
-            "validUntil": null
-          },
-          {
-            "code": "4",
-            "categoryTitle": [
-              {
-                "languageCode": "no",
-                "value": "Mastergrad"
-              }
-            ],
-            "validFrom": "1926-01-01",
-            "validUntil": null
-          },
-          {
-            "code": "5",
-            "categoryTitle": [
-              {
-                "languageCode": "no",
-                "value": "Doktorgrad"
-              }
-            ],
-            "validFrom": "1926-01-01",
-            "validUntil": null
-          }
+                "value": "Første publisering."
+            }
+        ],
+        "temporalEnd": {
+            "description": [
+                {
+                    "languageCode": "no",
+                    "value": "Variabelen blir ikke lenger oppdatert"
+                }
+            ]
+        },
+        "temporalCoverageStart": "1990-01-01",
+        "temporalCoverageLatest": "1994-01-01",
+        "temporalStatusDates": [
+            "1990-01-01",
+            "1991-01-01",
+            "1992-01-01",
+            "1993-01-01",
+            "1994-01-01"
         ]
-      },
-      "shortName": "UTDANNING"
-    }
-  ],
-  "shortName": "UTDANNING"
+    },
+    "measureVariables": [
+        {
+            "name": [
+                {
+                    "languageCode": "no",
+                    "value": "Utdanning"
+                }
+            ],
+            "description": [
+                {
+                    "languageCode": "no",
+                    "value": "Utdanningsnivå for person"
+                }
+            ],
+            "subjectFields": [
+                [
+                    {
+                        "languageCode": "no",
+                        "value": "Testdata"
+                    }
+                ]
+            ],
+            "dataType": "STRING",
+            "valueDomain": {
+                "codeList": [
+                    {
+                        "code": "1",
+                        "categoryTitle": [
+                            {
+                                "languageCode": "no",
+                                "value": "Grunnskole"
+                            }
+                        ],
+                        "validFrom": "1926-01-01",
+                        "validUntil": null
+                    },
+                    {
+                        "code": "2",
+                        "categoryTitle": [
+                            {
+                                "languageCode": "no",
+                                "value": "Videregående skole"
+                            }
+                        ],
+                        "validFrom": "1926-01-01",
+                        "validUntil": null
+                    },
+                    {
+                        "code": "3",
+                        "categoryTitle": [
+                            {
+                                "languageCode": "no",
+                                "value": "Bachelorgrad"
+                            }
+                        ],
+                        "validFrom": "1926-01-01",
+                        "validUntil": null
+                    },
+                    {
+                        "code": "4",
+                        "categoryTitle": [
+                            {
+                                "languageCode": "no",
+                                "value": "Mastergrad"
+                            }
+                        ],
+                        "validFrom": "1926-01-01",
+                        "validUntil": null
+                    },
+                    {
+                        "code": "5",
+                        "categoryTitle": [
+                            {
+                                "languageCode": "no",
+                                "value": "Doktorgrad"
+                            }
+                        ],
+                        "validFrom": "1926-01-01",
+                        "validUntil": null
+                    }
+                ]
+            },
+            "shortName": "UTDANNING"
+        }
+    ],
+    "shortName": "UTDANNING"
 }

--- a/tests/resources/worker/steps/transformer/input_data/UTDANNING_PATCH.json
+++ b/tests/resources/worker/steps/transformer/input_data/UTDANNING_PATCH.json
@@ -34,7 +34,18 @@
                 "value": "Første publisering."
             }
         ],
-        "temporalEndOfSeries": false
+        "temporalEnd": {
+            "description": [
+                {
+                    "languageCode": "no",
+                    "value": "Variabelen blir ikke lenger oppdatert"
+                }
+            ],
+            "successors": [
+                "UTDANNING_1",
+                "UTDANNING_2"
+            ]
+        }
     },
     "measureVariables": [
         {


### PR DESCRIPTION
Transforms the new `temporalEnd` field into the output model taking care of the optional fields.