### PR TITLE
Dynamic workers

### DIFF
--- a/job_executor/adapter/local_storage.py
+++ b/job_executor/adapter/local_storage.py
@@ -423,3 +423,13 @@ def delete_archived_input(dataset_name: str):
     archived_file: Path = INPUT_DIR / f"archive/{dataset_name}.tar"
     if archived_file.is_file():
         os.remove(archived_file)
+
+
+def get_size_in_bytes(dataset_name: str) -> int:
+    """
+    Returns the size of the .tar file
+    """
+    tar_path = INPUT_DIR / f"{dataset_name}.tar"
+    if not tar_path.exists():
+        return 0
+    return os.path.getsize(tar_path)

--- a/job_executor/config/environment.py
+++ b/job_executor/config/environment.py
@@ -13,6 +13,7 @@ def _initialize_environment() -> dict:
         "SECRETS_FILE": os.environ["SECRETS_FILE"],
         "DOCKER_HOST_NAME": os.environ["DOCKER_HOST_NAME"],
         "COMMIT_ID": os.environ["COMMIT_ID"],
+        "DYNAMIC_WORKER_THRESHOLD": os.environ["DYNAMIC_WORKER_THRESHOLD"],
     }
 
 

--- a/job_executor/worker/manager_state.py
+++ b/job_executor/worker/manager_state.py
@@ -1,0 +1,57 @@
+class ManagerState:
+    def __init__(
+        self,
+        default_max_workers=4,
+        dynamic_worker_threshold=50 * 1024**3,
+    ):
+        """
+        :param default_max_workers: The maximum number of workers
+        :param dynamic_worker_threshold: Threshold when the number of workers are reduced (50GB - 50 * 1024**3)
+        """
+        self.default_max_workers = default_max_workers
+        self.current_max_workers = default_max_workers
+        self.dynamic_worker_threshold = dynamic_worker_threshold
+
+        # Maps job_id -> dataset size = {jobid1: size_in_bytes, jobid2: size_in_bytes, ...}
+        self.datasets = {}
+
+    @property
+    def current_total_size(self):
+        return sum(self.datasets.values())
+
+    def can_spawn_new_worker(self, new_job_size):
+        """
+        Called to check if a new worker can be spawned. If the current total size of data being processed
+        is larger than the threshold the number of workers are reduced to 2.
+
+        When a job is finished and unregister the number of workers will reset to default_max_workers
+        """
+
+        # Could tweak this to be more gradual if we want
+        if self.current_total_size >= self.dynamic_worker_threshold:
+            self.current_max_workers = 2
+        else:
+            self.current_max_workers = self.default_max_workers
+
+        active_workers = len(self.datasets)
+        if active_workers >= self.current_max_workers:
+            return False
+
+        return True
+
+    def register_job(self, job_id, job_size):
+        """
+        Called when a worker picks up a job.
+        """
+        self.datasets[job_id] = job_size
+
+    def unregister_job(self, job_id):
+        """
+        Called when a job finishes or fails.
+        """
+        if job_id in self.datasets:
+            del self.datasets[job_id]
+
+    def reset(self):
+        self.current_max_workers = self.default_max_workers
+        self.datasets.clear()

--- a/tests/unit/worker/test_manager_state.py
+++ b/tests/unit/worker/test_manager_state.py
@@ -1,0 +1,72 @@
+from job_executor.worker.manager_state import ManagerState
+
+
+def test_initial_state():
+    manager_state = ManagerState()
+
+    assert manager_state.current_total_size == 0
+    assert len(manager_state.datasets) == 0
+
+
+def test_can_spawn_worker():
+    manager_state = ManagerState()
+
+    can_spawn = manager_state.can_spawn_new_worker(new_job_size=1)
+    assert can_spawn is True
+
+
+def test_can_not_spawn_worker_to_many_workers():
+    manager_state = ManagerState(default_max_workers=4)
+
+    # Register 4 jobs
+    for i in range(4):
+        manager_state.register_job(f"job_{i}", 1024)
+
+    can_spawn = manager_state.can_spawn_new_worker(new_job_size=1024)
+    assert can_spawn is False
+
+
+def test_can_not_spawn_worker_size_limit_reached():
+    manager_state = ManagerState(dynamic_worker_threshold=20 * 1024**3)  # 20GB
+
+    # register large job
+    manager_state.register_job("job_1", 20 * 1024**3)  # 20 GB
+
+    # Max worker should now be 2, We can still spawn a second job
+    can_spawn = manager_state.can_spawn_new_worker(new_job_size=10 * 1024**3)
+    assert can_spawn is True
+
+    manager_state.register_job("job_2", 10 * 1024**3)
+
+    # We should not be able to spawn a third job
+    can_spawn = manager_state.can_spawn_new_worker(new_job_size=10 * 1024**3)
+    assert can_spawn is False
+
+
+def test_unregister_job():
+    manager_state = ManagerState(default_max_workers=4)
+
+    for i in range(4):
+        manager_state.register_job(f"job_{i}", 1024)
+
+    can_spawn = manager_state.can_spawn_new_worker(new_job_size=1024)
+    assert can_spawn is False
+
+    manager_state.unregister_job("job_1")
+    can_spawn = manager_state.can_spawn_new_worker(new_job_size=1024)
+    assert can_spawn is True
+
+
+def test_reset():
+    manager_state = ManagerState(default_max_workers=4)
+
+    for i in range(4):
+        manager_state.register_job(f"job_{i}", 1024)
+
+    can_spawn = manager_state.can_spawn_new_worker(new_job_size=1024)
+    assert can_spawn is False
+
+    manager_state.reset()
+
+    can_spawn = manager_state.can_spawn_new_worker(new_job_size=1024)
+    assert can_spawn is True


### PR DESCRIPTION
Uses a class to store state about workers.

The class stores:
- default_max_workers - how many workers we usually want to use
- dynamic_worker_threshold - The limit where we want to reduce number of workers
- current_max_workers - the number of workers allowed
- datasets - dict with { job_id : size_in_bytes}

1. When we want to start a new job we first get get size
2. then we check if we are allowed to spawn a new job
3. if the total size of the datasets currently in the pipeline are above the threshold we reduce the number of workers
4. if we can spawn the new worker we register the job in the state
5. when the job finished we unregister the job


at the moment we check current_total_size meaning data already in the pipeline. 
```py
if self.current_total_size >= self.dynamic_worker_threshold:
```

so if the limit is 50gb and the there is currently 49 GB in the pipeline we will allow the next job in even if it will put the current_total_size well above the threshold. I figured this was ok since this threshold are mostly an guesstimate.

But we could just add if we want a safer/stricter approach:
```py
if (self.current_total_size+new_job_size) >= self.dynamic_worker_threshold:
```