### PR TITLE
Better metadata all draft write

### DIFF
--- a/job_executor/adapter/local_storage.py
+++ b/job_executor/adapter/local_storage.py
@@ -36,11 +36,11 @@ def _write_json(
 def _write_json_with_tmp(
     content: dict, file_path: Path, indent: int | None = None
 ) -> None:
-    tmp_name = f"{file_path}.tmp"
-    with open(tmp_name, "w", encoding="utf-8") as f:
+    tmp_file_path = f"{file_path}.tmp"
+    with open(tmp_file_path, "w", encoding="utf-8") as f:
         json.dump(content, f, indent=indent)
     os.remove(file_path)
-    shutil.move(tmp_name, file_path)
+    shutil.move(tmp_file_path, file_path)
 
 
 def _get_parquet_path(directory: Path, dataset_name: str) -> Path:

--- a/job_executor/model/datastore.py
+++ b/job_executor/model/datastore.py
@@ -88,8 +88,7 @@ class Datastore:
             )
             released_metadata = self.metadata_all_latest.get(dataset_name)
             patched_metadata = released_metadata.patch(draft_metadata)
-            self.metadata_all_draft.remove(dataset_name)
-            self.metadata_all_draft.add(patched_metadata)
+            self.metadata_all_draft.update_one(dataset_name, patched_metadata)
             self.draft_version.add(
                 DataStructureUpdate(
                     name=dataset_name,

--- a/job_executor/model/datastore.py
+++ b/job_executor/model/datastore.py
@@ -183,8 +183,7 @@ class Datastore:
             draft_metadata = Metadata(
                 **local_storage.get_working_dir_metadata(dataset_name)
             )
-            self.metadata_all_draft.remove(dataset_name)
-            self.metadata_all_draft.add(draft_metadata)
+            self.metadata_all_draft.update_one(dataset_name, draft_metadata)
             self.draft_version.add(
                 DataStructureUpdate(
                     name=dataset_name,

--- a/job_executor/model/metadata_all.py
+++ b/job_executor/model/metadata_all.py
@@ -65,6 +65,15 @@ class MetadataAllDraft(MetadataAll):
         ]
         self._write_to_file()
 
+    def update_one(self, dataset_name: str, metadata: Metadata):
+        self.data_structures = [
+            metadata
+            for metadata in self.data_structures
+            if metadata.name != dataset_name
+        ]
+        self.data_structures.append(metadata)
+        self._write_to_file()
+
     def remove_all(self):
         self.data_structures = []
         self._write_to_file()


### PR DESCRIPTION
- update_one: avoid persisting to files two times for dataset update operations
- write_to_json_with_tmp: avoid long writes and instead write to a tmp file and swap