### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-tools-version.yaml
+++ b/.github/workflows/update-tools-version.yaml
@@ -1,4 +1,7 @@
 name: Update Microdata Tools Version
+permissions:
+  contents: write
+  pull-requests: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/statisticsnorway/microdata-job-executor/security/code-scanning/11](https://github.com/statisticsnorway/microdata-job-executor/security/code-scanning/11)
[#180](https://github.com/statisticsnorway/microdata-job-executor/issues/180)

As discussed, it is not possible to add permissions to certain steps, hence the autofix-solution should be OK.

