### PR TITLE
Remove legacy env variables

### DIFF
--- a/job_executor/config/__init__.py
+++ b/job_executor/config/__init__.py
@@ -5,8 +5,6 @@ from dataclasses import dataclass
 
 @dataclass
 class Environment:
-    datastore_dir: str
-    datastore_rdn: str
     secrets_file: str
     pseudonym_service_url: str
     datastore_api_url: str
@@ -19,8 +17,6 @@ class Environment:
 
 def _initialize_environment() -> Environment:
     return Environment(
-        datastore_dir=os.environ["DATASTORE_DIR"],
-        datastore_rdn=os.environ["DATASTORE_RDN"],
         secrets_file=os.environ["SECRETS_FILE"],
         pseudonym_service_url=os.environ["PSEUDONYM_SERVICE_URL"],
         datastore_api_url=os.environ["DATASTORE_API_URL"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
 import os
 
-os.environ["DATASTORE_DIR"] = "tests/resources/datastores/TEST_DATASTORE"
-os.environ["DATASTORE_RDN"] = "no.ssb.test"
 os.environ["PSEUDONYM_SERVICE_URL"] = "http://mock.pseudonym.service"
 os.environ["DATASTORE_API_URL"] = "http://mock.job.service"
 os.environ["NUMBER_OF_WORKERS"] = "4"

--- a/tests/unit/adapter/test_datastore_api.py
+++ b/tests/unit/adapter/test_datastore_api.py
@@ -15,7 +15,7 @@ from job_executor.adapter.datastore_api.models import (
 from job_executor.common.exceptions import HttpResponseError
 
 DATASTORE_API_URL = os.environ["DATASTORE_API_URL"]
-DATASTORE_RDN = os.environ["DATASTORE_RDN"]
+DATASTORE_RDN = "no.ssb.test"
 JOB_ID = "123"
 JOB_LIST = [
     Job(

--- a/tests/unit/config/test_environment.py
+++ b/tests/unit/config/test_environment.py
@@ -4,7 +4,6 @@ from job_executor.config import environment
 
 
 def test_config_from_environment():
-    assert environment.datastore_dir == os.environ.get("DATASTORE_DIR")
     assert environment.pseudonym_service_url == (
         os.environ.get("PSEUDONYM_SERVICE_URL")
     )


### PR DESCRIPTION
Cleanup - [issue 467](https://github.com/orgs/statisticsnorway/projects/36/views/3?pane=issue&itemId=190014775&issue=statisticsnorway%7Cmicrodata-docker-compose%7C467)

Info about `DATASTORE_RDN` and `DATASTORE_DIR` is now received from datastore-api.