### PR TITLE
Analyze workflows with zizmor - a GitHub Actions security scanner

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
         patterns:
           - "*"   
     cooldown:
-      default-days: 3
+      default-days: 7
       semver-major-days: 30
       semver-minor-days: 14
       semver-patch-days: 3
@@ -33,7 +33,7 @@ updates:
       time: '06:00'
       timezone: 'Europe/Oslo'
     cooldown:
-      default-days: 3
+      default-days: 7
     groups:
       all-actions:
         patterns:
@@ -47,7 +47,7 @@ updates:
       time: '06:00'
       timezone: 'Europe/Oslo'
     cooldown:
-      default-days: 3
+      default-days: 7
     groups:
       all-docker:
         patterns:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,11 +1,16 @@
 name: Run Tests on PR
-permissions:
-  contents: read
+
 on:
   pull_request:
     branches:
       - "*"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   test:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -47,3 +47,5 @@ jobs:
       with:
         inputs: .github/
         advanced-security: false
+        min-severity: low
+        min-confidence: medium

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -37,3 +37,8 @@ jobs:
 
     - name: Run Ruff format
       run: uv run ruff format --diff
+
+    - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+      with:
+        inputs: .github/
+        advanced-security: false

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -47,7 +47,7 @@ jobs:
     needs: test
     permissions:
       contents: read
-      id-token: write
+      id-token: write # Required for GitHub OIDC token exchange in google-github-actions/auth
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -100,7 +100,7 @@ jobs:
     needs: build
     permissions:
       contents: read
-      id-token: write
+      id-token: write # Required for GitHub OIDC token exchange in downstream workflows
 
     steps:
       - name: Call workflow
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     permissions:
-      actions: write
+      actions: write # Required to cancel older workflow runs using gh run cancel
     steps:
       - name: Mark older approvals as unnecessary
         env:
@@ -144,7 +144,7 @@ jobs:
     environment: prod
     permissions:
       contents: read
-      id-token: write
+      id-token: write # Required for GitHub OIDC token exchange in downstream workflows
 
     steps:
       - name: Call workflow

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -20,6 +20,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -44,6 +46,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Authenticate to Google Cloud
         id: auth
@@ -115,7 +119,6 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Mark older approvals as unnecessary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -1,12 +1,16 @@
 name: Build
-permissions:
-  contents: read
 
 on:
   push:
     branches:
       - main
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
 
 env:
   REGISTRY: europe-north1-docker.pkg.dev/${{ secrets.GAR_PROJECT_ID }}/microdata-docker
@@ -38,6 +42,7 @@ jobs:
       run: uv run pytest
 
   build:
+    name: Build
     runs-on: ubuntu-latest
     needs: test
     permissions:
@@ -114,6 +119,7 @@ jobs:
             })
 
   revoke:
+    name: Revoke older approvals
     runs-on: ubuntu-latest
     needs: build
     permissions:

--- a/.github/workflows/update-tools-version.yaml
+++ b/.github/workflows/update-tools-version.yaml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Ensure the full history is fetched
+          persist-credentials: true
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/update-tools-version.yaml
+++ b/.github/workflows/update-tools-version.yaml
@@ -15,8 +15,8 @@ jobs:
   update-dependency:
     name: Update microdata-tools dependency
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # Required to commit and push the dependency bump branch
+      pull-requests: write # Required to open the pull request with gh pr create
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/update-tools-version.yaml
+++ b/.github/workflows/update-tools-version.yaml
@@ -1,15 +1,22 @@
 name: Update Microdata Tools Version
-permissions:
-  contents: write
-  pull-requests: write
 
 on:
   schedule:
     - cron: 0 10 * * * # Runs everyday at 10:00
   workflow_dispatch:  # Allows manual triggering of the workflow
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   update-dependency:
+    name: Update microdata-tools dependency
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
 
       - id: zizmor
         name: Lint GitHub Actions
-        entry: zizmor
+        entry: zizmor --show-audit-urls=always --min-severity=low --min-confidence=medium --pedantic .github/
         language: system
-        types: [ yaml ]
         files: ^\.github/.*
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,10 @@ repos:
         language: system
         files: ^(pyproject.toml|uv.lock)$
         pass_filenames: false
+
+      - id: zizmor
+        name: Lint GitHub Actions
+        entry: zizmor
+        language: system
+        types: [ yaml ]
+        files: ^\.github/.*

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Executes work for a datastore by polling a job-service for available jobs. Uses 
 
 ### Set up
 
-To work on this repository you need to install [uv](https://docs.astral.sh/uv/).
+To work on this repository you need to install [uv](https://docs.astral.sh/uv/) and [zizmore](https://docs.zizmor.sh/).
 After cloning the repo, install and activate an environment with:
 ```sh
 uv venv && uv sync && source .venv/bin/activate 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dev = [
 
 [tool.uv]
 package = true
-exclude-newer = "3 days"
+exclude-newer = "7 days"
 exclude-newer-package = { "microdata-tools" = "0 hours" }
 
 [tool.setuptools.packages.find]

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P3D"
+exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
 microdata-tools = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }


### PR DESCRIPTION
Adding [zizmor](https://docs.zizmor.sh/) to:
- pre-commit hooks
- PR workflow

Also fixed the reported findings.

Zizmor can run with more strict options: `--pedantic` or even stricter `--persona=auditor`.
Added concurrency settings as recommended (from `--pedantic` findings, https://docs.zizmor.sh/audits/#concurrency-limits)

List of projects using zizmor: https://docs.zizmor.sh/trophy-case/

Installation: https://docs.zizmor.sh/installation/
Audit rules: https://docs.zizmor.sh/audits/

To run manually from project root:
`zizmor .github --show-audit-urls always`

After merging this PR run:
`pre-commit install`
