### PR TITLE
Adjust zizmor confidence levels and update dependabot patch days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
       default-days: 7
       semver-major-days: 30
       semver-minor-days: 14
-      semver-patch-days: 3
+      semver-patch-days: 7
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -48,4 +48,4 @@ jobs:
         inputs: .github/
         advanced-security: false
         min-severity: low
-        min-confidence: medium
+        min-confidence: low

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -100,7 +100,6 @@ jobs:
     needs: build
     permissions:
       contents: read
-      id-token: write # Required for GitHub OIDC token exchange in downstream workflows
 
     steps:
       - name: Call workflow
@@ -147,7 +146,6 @@ jobs:
     environment: prod
     permissions:
       contents: read
-      id-token: write # Required for GitHub OIDC token exchange in downstream workflows
 
     steps:
       - name: Call workflow

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
 
       - id: zizmor
         name: Lint GitHub Actions
-        entry: zizmor --show-audit-urls=always --min-severity=low --min-confidence=medium --pedantic .github/
+        entry: zizmor --show-audit-urls=always --min-severity=low --min-confidence=low --pedantic .github/
         language: system
         files: ^\.github/.*
         pass_filenames: false


### PR DESCRIPTION
min-confidence=medium didn't catch the persist-credentials on actions/checkout.